### PR TITLE
BE-STAGING-FIX-01: Branding correto em emails #361

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -306,7 +306,7 @@ class AppointmentAdmin(admin.ModelAdmin):
 
         try:
             if not change:
-                salon_name = obj.tenant.name if obj.tenant else "Salonix"
+                salon_name = obj.tenant.name if obj.tenant else "TimelyOne"
                 send_appointment_confirmation_email(
                     to_email=recipient_email,
                     client_name=client_display_name,
@@ -317,7 +317,7 @@ class AppointmentAdmin(admin.ModelAdmin):
             elif previous_status != "cancelled" and obj.status == "cancelled":
                 salon_email = obj.professional.user.email if obj.professional else ""
                 if salon_email:
-                    salon_name = obj.tenant.name if obj.tenant else "Salonix"
+                    salon_name = obj.tenant.name if obj.tenant else "TimelyOne"
                     send_appointment_cancellation_email(
                         client_email=recipient_email,
                         salon_email=salon_email,

--- a/core/email_utils.py
+++ b/core/email_utils.py
@@ -21,7 +21,9 @@ def _send_email_safe(
     Captura exceções e loga erros em vez de quebrar o fluxo.
     """
     if getattr(settings, "EMAIL_DISABLE_OUTBOUND", False):
-        logger.info(f"[email] outbound disabled — would send '{subject}' to {to_emails}")
+        logger.info(
+            f"[email] outbound disabled — would send '{subject}' to {to_emails}"
+        )
         return True
 
     if isinstance(to_emails, str):
@@ -37,7 +39,7 @@ def _send_email_safe(
         )
         if body_html:
             email.attach_alternative(body_html, "text/html")
-        
+
         email.send(fail_silently=False)
         logger.info(f"E-mail '{subject}' enviado com sucesso para {to_emails}")
         return True
@@ -52,13 +54,13 @@ def _send_email_safe(
                     "backend": settings.EMAIL_BACKEND,
                     "user": settings.EMAIL_HOST_USER,  # Cuidado com PII/Secrets, mas user ok
                 }
-            }
+            },
         )
         return False
 
 
 def send_appointment_confirmation_email(
-    to_email, client_name, service_name, date_time, salon_name="Salonix"
+    to_email, client_name, service_name, date_time, salon_name="TimelyOne"
 ):
     """
     Envia e-mail de confirmação de agendamento.
@@ -86,7 +88,7 @@ def send_appointment_confirmation_email(
     # Opcional: Adicionar versão HTML simples se desejado, mas mantendo compatibilidade com texto plano
     # Por enquanto mantemos texto plano como principal, mas podemos enriquecer depois.
     # O código original tinha MIMEText(body, "plain"), então vamos manter assim.
-    
+
     _send_email_safe(subject, body, None, to_email)
 
 
@@ -96,7 +98,7 @@ def send_appointment_cancellation_email(
     client_name,
     service_name,
     date_time,
-    salon_name="Salonix",
+    salon_name="TimelyOne",
 ):
     """
     Envia e-mail de cancelamento de agendamento para o cliente e o salão.
@@ -130,11 +132,12 @@ def send_staff_access_link_email(to_email, access_url, salon_name):
     Envia e-mail com link de acesso rápido para staff.
     """
     subject = _("Seu link de acesso ao %(salon_name)s") % {"salon_name": salon_name}
-    
+
     body = (
         _("Olá,")
         + "\n\n"
-        + _("Você solicitou um link de acesso para o salão %(salon_name)s.") % {"salon_name": salon_name}
+        + _("Você solicitou um link de acesso para o salão %(salon_name)s.")
+        % {"salon_name": salon_name}
         + "\n\n"
         + _("Clique no link abaixo para acessar:")
         + "\n"
@@ -152,7 +155,7 @@ def send_bulk_appointment_confirmation_email(
     to_email: str,
     client_name: str,
     items: list[dict],
-    salon_name: str = "Salonix",
+    salon_name: str = "TimelyOne",
 ):
     """
     Envia um único e-mail consolidado com múltiplos agendamentos.
@@ -270,7 +273,7 @@ def send_marketing_email(
     *,
     tenant_id: int,
     customer_id: int,
-    salon_name: str = "Salonix",
+    salon_name: str = "TimelyOne",
 ):
     """
     Envia e-mail de marketing com link de descadastro (unsubscribe).
@@ -310,11 +313,11 @@ def send_marketing_email(
 def send_staff_invite_email(
     to_email: str,
     accept_url: str,
-    salon_name: str = "Salonix",
+    salon_name: str = "TimelyOne",
     inviter_name: str | None = None,
 ):
     subject = "Convite para acessar o painel do salão"
-    
+
     inviter_line = (
         f"{inviter_name} convidou você para acessar o painel do {salon_name}."
         if inviter_name

--- a/core/management/commands/test_smtp.py
+++ b/core/management/commands/test_smtp.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
                     self.stdout.write("Logging in...")
                     server.login(settings.EMAIL_HOST_USER, settings.EMAIL_HOST_PASSWORD)
                     
-                    msg = f"Subject: Test Email (Native)\n\nThis is a test email from Salonix using native smtplib."
+                    msg = f"Subject: Test Email (Native)\n\nThis is a test email from TimelyOne using native smtplib."
                     self.stdout.write(f"Sending to {to_email}...")
                     server.sendmail(settings.EMAIL_HOST_USER, [to_email], msg)
                     self.stdout.write(self.style.SUCCESS('Successfully sent email via native smtplib'))
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             try:
                 send_mail(
                     'Test Email (Django)',
-                    'This is a test email from Salonix using Django send_mail.',
+                    'This is a test email from TimelyOne using Django send_mail.',
                     settings.EMAIL_HOST_USER,
                     [to_email],
                     fail_silently=False,

--- a/core/tests/test_bulk_confirmation_email.py
+++ b/core/tests/test_bulk_confirmation_email.py
@@ -48,7 +48,7 @@ def test_send_bulk_email_multipart_and_links(settings, with_professional):
         to_email="alana@example.com",
         client_name="Alana Nogueira",
         items=items,
-        salon_name="Salonix",
+        salon_name="TimelyOne",
     )
 
     # Verificações usando django.core.mail.outbox

--- a/core/utils/ics.py
+++ b/core/utils/ics.py
@@ -90,7 +90,7 @@ class ICSGenerator:
         ics_content = [
             "BEGIN:VCALENDAR",
             "VERSION:2.0",
-            "PRODID:-//Salonix//Appointment//EN",
+            "PRODID:-//TimelyOne//Appointment//EN",
             "CALSCALE:GREGORIAN",
             "METHOD:PUBLISH",
             "BEGIN:VEVENT",

--- a/core/views.py
+++ b/core/views.py
@@ -506,7 +506,7 @@ class AppointmentCreateView(TenantIsolatedMixin, CreateAPIView):
                     )
                 )
                 salon_name = (
-                    appointment.tenant.name if appointment.tenant else "Salonix"
+                    appointment.tenant.name if appointment.tenant else "TimelyOne"
                 )
                 send_appointment_confirmation_email(
                     to_email=recipient_email,
@@ -891,7 +891,7 @@ class BulkAppointmentCreateView(TenantIsolatedMixin, APIView):
                             to_email=recipient_email,
                             client_name=str(client_display_name or "Cliente"),
                             items=consolidated_items,
-                            salon_name=(tenant.name if tenant else "Salonix"),
+                            salon_name=(tenant.name if tenant else "TimelyOne"),
                         )
                 except Exception as e:  # pragma: no cover
                     logger.warning(
@@ -1372,7 +1372,7 @@ class MixedBulkAppointmentCreateView(TenantIsolatedMixin, APIView):
                     to_email=recipient_email,
                     client_name=str(client_display_name or "Cliente"),
                     items=consolidated_items,
-                    salon_name=(tenant.name if tenant else "Salonix"),
+                    salon_name=(tenant.name if tenant else "TimelyOne"),
                 )
         except Exception as e:  # pragma: no cover
             logger.warning(
@@ -2089,7 +2089,7 @@ class AppointmentCancelView(APIView):
             salon_email = appointment.professional.user.email
             if client_email:
                 salon_name = (
-                    appointment.tenant.name if appointment.tenant else "Salonix"
+                    appointment.tenant.name if appointment.tenant else "TimelyOne"
                 )
                 send_appointment_cancellation_email(
                     client_email=client_email,
@@ -2843,7 +2843,7 @@ class ClientsMeAppointmentCreateView(APIView):
             to_email = (customer.email or "").strip()
             if to_email:
                 client_name = customer.name or "Cliente"
-                salon_name = tenant.name or "Salonix"
+                salon_name = tenant.name or "TimelyOne"
                 send_appointment_confirmation_email(
                     to_email=to_email,
                     client_name=client_name,

--- a/notifications/services.py
+++ b/notifications/services.py
@@ -50,14 +50,14 @@ def send_customer_pwa_invite(
     sep = "&" if tenant_qs else ""
     link = f"{base}/client/access?{tenant_qs}{sep}token={token}"
 
-    subject = "Seu acesso ao Salonix"
+    subject = f"Seu acesso ao {getattr(tenant, 'name', 'TimelyOne')}"
     sender_email = settings.EMAIL_HOST_USER or getattr(
         settings, "DEFAULT_FROM_EMAIL", "noreply@localhost"
     )
 
     text_body = (
         f"Olá,\n\n"
-        f"Para acessar sua área de cliente, utilize o link abaixo:\n\n"
+        f"Para acessar sua área de cliente no {getattr(tenant, 'name', 'TimelyOne')}, utilize o link abaixo:\n\n"
         f"{link}\n\n"
         f"Se você não solicitou este acesso, ignore esta mensagem.\n"
     )
@@ -65,9 +65,14 @@ def send_customer_pwa_invite(
     html_body = f"""
     <div style="font-family: Arial, sans-serif;">
       <p>Olá,</p>
-      <p>Para acessar sua área de cliente, utilize o link abaixo:</p>
+      <p>Para acessar sua área de cliente no <strong>{getattr(tenant, 'name', 'TimelyOne')}</strong>, utilize o link abaixo:</p>
       <p><a href="{link}" style="background:#2563eb;color:#fff;padding:10px 14px;border-radius:6px;text-decoration:none">Acessar</a></p>
       <p>Se você não solicitou este acesso, ignore esta mensagem.</p>
+      <hr style="border: 0; border-top: 1px solid #eee; margin: 20px 0;">
+      <p style="font-size: 12px; color: #777;">
+        {getattr(tenant, 'name', 'TimelyOne')}<br>
+        Esta é uma mensagem automática.
+      </p>
     </div>
     """
 

--- a/ops/migrations/0003_auto_20251223_1613.py
+++ b/ops/migrations/0003_auto_20251223_1613.py
@@ -2,9 +2,10 @@
 
 from django.db import migrations
 
+
 def seed_notification_templates(apps, schema_editor):
     OpsNotificationTemplate = apps.get_model("ops", "OpsNotificationTemplate")
-    
+
     # 1. PWA_INVITE
     pwa_invite_text = (
         "Olá,\n\n"
@@ -14,29 +15,29 @@ def seed_notification_templates(apps, schema_editor):
     )
     pwa_invite_html = (
         '<div style="font-family: Arial, sans-serif;">\n'
-        '  <p>Olá,</p>\n'
-        '  <p>Para acessar sua área de cliente, utilize o link abaixo:</p>\n'
+        "  <p>Olá,</p>\n"
+        "  <p>Para acessar sua área de cliente, utilize o link abaixo:</p>\n"
         '  <p><a href="{{ link }}" style="background:#2563eb;color:#fff;padding:10px 14px;border-radius:6px;text-decoration:none">Acessar</a></p>\n'
-        '  <p>Se você não solicitou este acesso, ignore esta mensagem.</p>\n'
-        '</div>'
+        "  <p>Se você não solicitou este acesso, ignore esta mensagem.</p>\n"
+        "</div>"
     )
-    
+
     OpsNotificationTemplate.objects.get_or_create(
         code="PWA_INVITE",
         channel="email",
         defaults={
-            "subject": "Seu acesso ao Salonix",
+            "subject": "Seu acesso ao TimelyOne",
             "body_text": pwa_invite_text,
             "body_html": pwa_invite_html,
             "is_active": True,
-        }
+        },
     )
 
     # 2. APPOINTMENT_CONFIRMATION
     # Original used %(client_name)s style formatting, converting to {{ client_name }} for Jinja2/Liquid style which is more standard for templates
     # or keep as python format if we plan to use python format.
     # Given the frontend showed {{ variable }}, I will convert to {{ variable }}.
-    
+
     appt_conf_text = (
         "Olá {{ client_name }},\n\n"
         'Seu agendamento para o serviço "{{ service_name }}" foi confirmado com sucesso!\n\n'
@@ -44,16 +45,16 @@ def seed_notification_templates(apps, schema_editor):
         "Caso precise remarcar ou cancelar, entre em contato conosco com antecedência.\n\n"
         "Obrigado por escolher {{ salon_name }}! 💈"
     )
-    
+
     OpsNotificationTemplate.objects.get_or_create(
         code="APPOINTMENT_CONFIRMATION",
         channel="email",
         defaults={
             "subject": "Confirmação do seu agendamento",
             "body_text": appt_conf_text,
-            "body_html": "", # No HTML version found in code, defaulting to empty or same as text wrapped in <p>
+            "body_html": "",  # No HTML version found in code, defaulting to empty or same as text wrapped in <p>
             "is_active": True,
-        }
+        },
     )
 
     # 3. APPOINTMENT_CANCELLATION
@@ -61,7 +62,7 @@ def seed_notification_templates(apps, schema_editor):
         "Olá {{ client_name }},\n\n"
         'O seu agendamento para o serviço "{{ service_name }}", marcado para {{ formatted_date }}, foi cancelado com sucesso.'
     )
-    
+
     OpsNotificationTemplate.objects.get_or_create(
         code="APPOINTMENT_CANCELLATION",
         channel="email",
@@ -70,8 +71,9 @@ def seed_notification_templates(apps, schema_editor):
             "body_text": appt_cancel_text,
             "body_html": "",
             "is_active": True,
-        }
+        },
     )
+
 
 class Migration(migrations.Migration):
 
@@ -80,5 +82,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(seed_notification_templates, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(
+            seed_notification_templates, reverse_code=migrations.RunPython.noop
+        ),
     ]

--- a/payments/views.py
+++ b/payments/views.py
@@ -507,6 +507,14 @@ class StripeWebhookView(APIView):
                                 else Decimal("0.00")
                             )
                             trial_end_ts = sub.get("trial_end")
+                            
+                            # DIAGNOSTICO STAGING: Logar detalhes do trial/créditos
+                            logger.info(
+                                f"[WEBHOOK] Checkout Session Completed: status={status}, "
+                                f"plan={plan_code}, credits={credits_included}, "
+                                f"trial_end={trial_end_ts}, sub_id={subscription_id}"
+                            )
+
                             if (
                                 status == "trialing"
                                 and credits_included > 0

--- a/salonix_backend/admin.py
+++ b/salonix_backend/admin.py
@@ -46,13 +46,13 @@ from payments.admin import PaymentCustomerAdmin, SubscriptionAdmin
 from datetime import datetime, timedelta
 
 
-class SalonixAdminSite(AdminSite):
+class TimelyOneAdminSite(AdminSite):
     """
-    Site Admin personalizado do Salonix com dashboard estatístico.
+    Site Admin personalizado do TimelyOne com dashboard estatístico.
     """
 
-    site_title = "Salonix Admin"
-    site_header = "🏢 Salonix - Gestão de Salões"
+    site_title = "TimelyOne Admin"
+    site_header = "🏢 TimelyOne - Gestão de Salões"
     index_title = "Dashboard de Administração"
 
     def get_urls(self):
@@ -264,7 +264,7 @@ class SalonixAdminSite(AdminSite):
 
 
 # Instância personalizada do admin
-admin_site = SalonixAdminSite(name="salonix_admin")
+admin_site = TimelyOneAdminSite(name="timelyone_admin")
 
 admin_site.register(Tenant, TenantAdmin)
 admin_site.register(CustomUser, CustomUserAdmin)

--- a/salonix_backend/admin_permissions.py
+++ b/salonix_backend/admin_permissions.py
@@ -120,8 +120,8 @@ def create_admin_groups():
     """
     from django.contrib.auth.models import Group, Permission
 
-    # Grupo: Administradores Salonix
-    admin_group, created = Group.objects.get_or_create(name="Salonix Admins")
+    # Grupo: Administradores TimelyOne
+    admin_group, created = Group.objects.get_or_create(name="TimelyOne Admins")
     if created:
         # Adicionar todas as permissões customizadas
         custom_perms = Permission.objects.filter(

--- a/salonix_backend/admin_simple.py
+++ b/salonix_backend/admin_simple.py
@@ -25,8 +25,8 @@ class SimpleAdminSite(AdminSite):
     Site Admin simples mas com ModelAdmin personalizados.
     """
 
-    site_title = "Salonix Admin"
-    site_header = "🏢 Salonix - Gestão de Salões"
+    site_title = "TimelyOne Admin"
+    site_header = "🏢 TimelyOne - Gestão de Salões"
     index_title = "Dashboard de Administração"
 
 

--- a/salonix_backend/apps.py
+++ b/salonix_backend/apps.py
@@ -5,4 +5,4 @@ from typing import ClassVar
 class SalonixBackendConfig(AppConfig):
     default_auto_field: ClassVar[str] = "django.db.models.BigAutoField"
     name = "salonix_backend"
-    verbose_name = "Salonix Backend"
+    verbose_name = "TimelyOne Backend"

--- a/salonix_backend/error_examples.py
+++ b/salonix_backend/error_examples.py
@@ -110,7 +110,7 @@ def example_external_service(request):
         return Response({"data": response.json()})
 
     except requests.Timeout:
-        raise SalonixError(
+        raise TimelyOneError(
             "Timeout ao conectar com serviço externo",
             code=ErrorCodes.SYSTEM_EXTERNAL_SERVICE_ERROR,
             details={"service": "example_api", "timeout": 5, "retry_after": 60},
@@ -118,7 +118,7 @@ def example_external_service(request):
         )
 
     except requests.RequestException as e:
-        raise SalonixError(
+        raise TimelyOneError(
             "Erro na comunicação com serviço externo",
             code=ErrorCodes.SYSTEM_EXTERNAL_SERVICE_ERROR,
             details={"service": "example_api", "error": str(e)},

--- a/salonix_backend/error_handling.py
+++ b/salonix_backend/error_handling.py
@@ -1,5 +1,5 @@
 """
-Sistema de tratamento de erros padronizado para Salonix Backend.
+Sistema de tratamento de erros padronizado para TimelyOne Backend.
 
 Este módulo fornece:
 - Códigos de erro padronizados
@@ -79,7 +79,7 @@ class ErrorCodes:
 
 
 class SalonixError(APIException):
-    """Exceção base para erros específicos do Salonix."""
+    """Exceção base para erros específicos do TimelyOne."""
 
     def __init__(
         self,

--- a/salonix_backend/logging_utils.py
+++ b/salonix_backend/logging_utils.py
@@ -1,5 +1,5 @@
 """
-Utilitários para logging estruturado do Salonix Backend.
+Utilitários para logging estruturado do TimelyOne Backend.
 """
 
 import json

--- a/salonix_backend/management/commands/setup_admin.py
+++ b/salonix_backend/management/commands/setup_admin.py
@@ -27,8 +27,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--superuser-email",
             type=str,
-            default="admin@salonix.pt",
-            help="Email do superusuário (default: admin@salonix.pt)",
+            default="admin@timelyone.com",
+            help="Email do superusuário (default: admin@timelyone.com)",
         )
 
     def handle(self, *args, **options):
@@ -70,11 +70,11 @@ class Command(BaseCommand):
             username="admin",
             email=email,
             password="admin123",  # Senha temporária
-            salon_name="Salonix Admin",
+            salon_name="TimelyOne Admin",
         )
 
-        # Adicionar ao grupo Salonix Admins
-        admin_group = Group.objects.get(name="Salonix Admins")
+        # Adicionar ao grupo TimelyOne Admins
+        admin_group = Group.objects.get(name="TimelyOne Admins")
         superuser.groups.add(admin_group)
 
         self.stdout.write(self.style.SUCCESS(f"✅ Superusuário criado: {email}"))

--- a/salonix_backend/settings.py
+++ b/salonix_backend/settings.py
@@ -470,7 +470,7 @@ EMAIL_USE_SSL = str(env_get("EMAIL_USE_SSL", "false")).lower() in {
 }
 EMAIL_HOST_USER = env_get("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = env_get("EMAIL_HOST_PASSWORD", "")
-DEFAULT_FROM_EMAIL = env_get("DEFAULT_FROM_EMAIL", "no-reply@localhost")
+DEFAULT_FROM_EMAIL = env_get("DEFAULT_FROM_EMAIL", "TimelyOne <no-reply@timelyone.com>")
 
 # Base para geração de links públicos de download de ICS
 # Ex.: http://api.timelyone.com
@@ -524,7 +524,7 @@ REPORTS_PAGINATION = {
 }
 
 SPECTACULAR_SETTINGS = {
-    "TITLE": "Salonix API",
+    "TITLE": "TimelyOne API",
     "DESCRIPTION": "Documentação dos relatórios e demais endpoints.",
     "VERSION": "1.0.0",
     # opcional:

--- a/salonix_backend/validators.py
+++ b/salonix_backend/validators.py
@@ -1,5 +1,5 @@
 """
-Sistema de validações centralizado para Salonix Backend.
+Sistema de validações centralizado para TimelyOne Backend.
 
 Este módulo fornece:
 - Validadores customizados reutilizáveis

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -61,7 +61,7 @@ class TestDjangoAdmin:
         # Acessar admin
         response = self.client.get("/admin/")
         assert response.status_code == 200
-        assert "Salonix - Gestão de Salões" in response.content.decode()
+        assert "TimelyOne - Gestão de Salões" in response.content.decode()
 
     def test_admin_login_staff(self):
         """Testa login de usuário staff no admin."""
@@ -227,13 +227,13 @@ class TestDjangoAdmin:
             series=series,
         )
 
-        list_url = reverse("salonix_admin:core_appointmentseries_changelist")
+        list_url = reverse("timelyone_admin:core_appointmentseries_changelist")
         list_response = self.client.get(list_url)
         assert list_response.status_code == 200
         assert f">{series.id}<" in list_response.content.decode()
 
         detail_url = reverse(
-            "salonix_admin:core_appointmentseries_change", args=[series.pk]
+            "timelyone_admin:core_appointmentseries_change", args=[series.pk]
         )
         detail = self.client.get(detail_url)
         assert detail.status_code == 200
@@ -278,11 +278,11 @@ class TestDjangoAdmin:
             series=series,
         )
 
-        appointments_url = reverse("salonix_admin:core_appointment_changelist")
+        appointments_url = reverse("timelyone_admin:core_appointment_changelist")
         response = self.client.get(f"{appointments_url}?series__id__exact={series.pk}")
         assert response.status_code == 200
         expected_link = reverse(
-            "salonix_admin:core_appointmentseries_change", args=[series.pk]
+            "timelyone_admin:core_appointmentseries_change", args=[series.pk]
         )
         assert expected_link in response.content.decode()
 
@@ -311,14 +311,14 @@ class TestAdminPermissions(TestCase):
 
     def test_admin_groups_created(self):
         """Testa se grupos administrativos foram criados."""
-        expected_groups = ["Salonix Admins", "Tenant Managers", "Support"]
+        expected_groups = ["TimelyOne Admins", "Tenant Managers", "Support"]
 
         for group_name in expected_groups:
             assert Group.objects.filter(name=group_name).exists()
 
     def test_admin_group_permissions(self):
         """Testa se grupos têm as permissões corretas."""
-        admin_group = Group.objects.get(name="Salonix Admins")
+        admin_group = Group.objects.get(name="TimelyOne Admins")
 
         # Verificar se grupo admin tem permissões customizadas
         custom_perms = admin_group.permissions.filter(
@@ -342,10 +342,10 @@ class TestAdminPermissions(TestCase):
         )
 
         # Adicionar ao grupo admin
-        admin_group = Group.objects.get(name="Salonix Admins")
+        admin_group = Group.objects.get(name="TimelyOne Admins")
         user.groups.add(admin_group)
 
-        assert user.groups.filter(name="Salonix Admins").exists()
+        assert user.groups.filter(name="TimelyOne Admins").exists()
         assert user.has_perm("users.view_all_tenants") or user.is_superuser
 
 

--- a/users/views.py
+++ b/users/views.py
@@ -894,7 +894,7 @@ class TenantStaffView(APIView):
                 ok = send_staff_invite_email(
                     to_email=to_email,
                     accept_url=accept_url,
-                    salon_name=tenant.name or "Salonix",
+                    salon_name=tenant.name or "TimelyOne",
                     inviter_name=inviter_name,
                 )
                 USERS_STAFF_INVITE_EVENTS_TOTAL.labels(
@@ -1044,7 +1044,7 @@ class TenantStaffResendInviteView(APIView):
             ok = send_staff_invite_email(
                 to_email=to_email,
                 accept_url=accept_url,
-                salon_name=tenant.name or "Salonix",
+                salon_name=tenant.name or "TimelyOne",
                 inviter_name=inviter_name,
             )
             USERS_STAFF_INVITE_EVENTS_TOTAL.labels(
@@ -1157,7 +1157,7 @@ class TenantStaffAccessLinkView(APIView):
                 send_staff_access_link_email(
                     to_email=to_email,
                     access_url=link,
-                    salon_name=tenant.name or "Salonix",
+                    salon_name=tenant.name or "TimelyOne",
                 )
             except Exception:
                 pass


### PR DESCRIPTION
- Branding "TimelyOne" :

- Substituídas referências hardcoded de "Salonix" no código Python ( settings.py , email_utils.py , Admin Sites).
- Prioridade : O sistema agora usa o nome do Tenant (ex: "Salão Top") e faz fallback para "TimelyOne" apenas se necessário.
- DEFAULT_FROM_EMAIL atualizado para usar o domínio/nome correto.
- Staging Fixes (Diagnóstico) :

- Créditos/Trial : Adicionado log detalhado no webhook do Stripe ( payments/views.py ) para investigar por que o bônus de 5€ do plano Standard não estava entrando.
- Link de Acesso (PWA) : Corrigido o notifications/services.py para que o email de convite exiba o nome do salão corretamente no assunto e corpo, em vez de um texto genérico.
- Qualidade :

- Corrigi os testes automatizados ( tests/test_admin.py ) que falhavam devido à renomeação dos grupos de admin.
- Status dos Testes : 537 testes passando (Verde).