### PR TITLE
BE-BOOKING-03: Auto-criacao de slot ao criar agendamento sem slot_id …

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -321,6 +321,12 @@ class SalonCustomerMiniSerializer(serializers.ModelSerializer):
 
 
 class AppointmentSerializer(serializers.ModelSerializer):
+    slot = serializers.PrimaryKeyRelatedField(
+        queryset=ScheduleSlot.objects.all(), required=False, allow_null=True
+    )
+    start_time = serializers.DateTimeField(required=False, write_only=True)
+    end_time = serializers.DateTimeField(required=False, write_only=True)
+
     class Meta:
         model = Appointment
         fields = [
@@ -330,6 +336,8 @@ class AppointmentSerializer(serializers.ModelSerializer):
             "service",
             "professional",
             "slot",
+            "start_time",
+            "end_time",
             "notes",
             "created_at",
             "status",
@@ -338,13 +346,11 @@ class AppointmentSerializer(serializers.ModelSerializer):
         read_only_fields = ["client", "created_at", "cancelled_by"]
 
     def validate_notes(self, value):
-        """Validar e sanitizar notas do agendamento."""
         if value:
             return sanitize_text_input(value, max_length=500)
         return value
 
     def validate(self, data):
-        """Validação completa do agendamento."""
         request = self.context.get("request")
         user = request.user if request else None
         tenant = getattr(request, "tenant", None) if request else None
@@ -354,31 +360,51 @@ class AppointmentSerializer(serializers.ModelSerializer):
             self.context.get("enforce_client_slot_uniqueness")
         )
 
-        # Validações básicas existentes
         slot = data.get("slot")
         professional = data.get("professional")
+        start_time = data.get("start_time")
+        end_time = data.get("end_time")
 
         errors = {}
 
-        # 1. Verifica se o slot está disponível
-        if slot and not slot.is_available:
-            errors["slot"] = "Este horário já foi agendado."
+        if slot is None:
+            # Caminho de auto-criação: exige start_time, end_time e professional
+            if not start_time:
+                errors["start_time"] = "Informe start_time quando slot não for fornecido."
+            if not end_time:
+                errors["end_time"] = "Informe end_time quando slot não for fornecido."
+            if not professional:
+                errors["professional"] = "Informe professional quando slot não for fornecido."
 
-        # 2. Verifica se o slot é do profissional informado
-        if slot and professional and slot.professional != professional:
-            errors["slot"] = "Este horário não pertence ao profissional informado."
-
-        # 3. Verifica se o slot está no futuro
-        if slot and slot.start_time <= timezone.now():
-            errors["slot"] = "Não é possível agendar horários no passado."
-
-        # 4. Verifica se o cliente já tem um agendamento para o mesmo slot
-        if user and slot and enforce_client_slot_uniqueness:
-            base_qs = Appointment.objects.filter(client=user, slot=slot)
-            if self.instance:
-                base_qs = base_qs.exclude(pk=self.instance.pk)
-            if base_qs.exclude(status="cancelled").exists():
-                errors["slot"] = "Você já tem um agendamento para este horário."
+            if not errors:
+                if end_time <= start_time:
+                    errors["end_time"] = "end_time deve ser posterior a start_time."
+                elif start_time <= timezone.now():
+                    errors["start_time"] = "Não é possível agendar horários no passado."
+                else:
+                    # Verifica sobreposição com slots já existentes do profissional
+                    overlap = ScheduleSlot.objects.filter(
+                        professional=professional,
+                        start_time__lt=end_time,
+                        end_time__gt=start_time,
+                        status="booked",
+                    ).exists()
+                    if overlap:
+                        errors["start_time"] = "O profissional já tem um agendamento neste horário."
+        else:
+            # Caminho tradicional: slot fornecido
+            if not slot.is_available:
+                errors["slot"] = "Este horário já foi agendado."
+            elif professional and slot.professional != professional:
+                errors["slot"] = "Este horário não pertence ao profissional informado."
+            elif slot.start_time <= timezone.now():
+                errors["slot"] = "Não é possível agendar horários no passado."
+            elif user and enforce_client_slot_uniqueness:
+                base_qs = Appointment.objects.filter(client=user, slot=slot)
+                if self.instance:
+                    base_qs = base_qs.exclude(pk=self.instance.pk)
+                if base_qs.exclude(status="cancelled").exists():
+                    errors["slot"] = "Você já tem um agendamento para este horário."
 
         if customer is None and self.instance is not None:
             customer = self.instance.customer
@@ -397,12 +423,10 @@ class AppointmentSerializer(serializers.ModelSerializer):
         if errors:
             raise serializers.ValidationError(errors)
 
-        # Usar validação avançada se tenant estiver disponível
-        if tenant:
+        if slot is not None and tenant:
             try:
                 data = validate_appointment_data(data, tenant, user)
             except Exception:
-                # Se a validação avançada falhar, manter validação básica
                 pass
 
         return data

--- a/core/tests/test_appointment_auto_slot.py
+++ b/core/tests/test_appointment_auto_slot.py
@@ -1,0 +1,175 @@
+import pytest
+from datetime import timedelta
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from users.models import Tenant, CustomUser, TenantStaffMember
+from core.models import Professional, Service, ScheduleSlot, Appointment
+
+URL = "/api/appointments/"
+
+FUTURE = timezone.now() + timedelta(days=1)
+FUTURE_START = FUTURE.replace(minute=0, second=0, microsecond=0)
+FUTURE_END = FUTURE_START + timedelta(hours=1)
+
+
+def _make_setup(slug):
+    tenant = Tenant.objects.create(name=f"Salon {slug}", slug=slug, is_active=True)
+    owner = CustomUser.objects.create_user(
+        username=f"owner_{slug}", email=f"owner_{slug}@example.com",
+        password="Pass123!", tenant=tenant,
+    )
+    TenantStaffMember.objects.create(
+        tenant=tenant, user=owner,
+        role=TenantStaffMember.Role.OWNER, status=TenantStaffMember.Status.ACTIVE,
+    )
+    prof_user = CustomUser.objects.create_user(
+        username=f"prof_{slug}", email=f"prof_{slug}@example.com",
+        password="Pass123!", tenant=tenant,
+    )
+    prof_staff = TenantStaffMember.objects.create(
+        tenant=tenant, user=prof_user,
+        role=TenantStaffMember.Role.COLLABORATOR, status=TenantStaffMember.Status.ACTIVE,
+    )
+    professional = Professional.objects.create(
+        tenant=tenant, user=prof_user, staff_member=prof_staff,
+        name="Ana Lima", is_active=True,
+    )
+    service = Service.objects.create(
+        tenant=tenant, user=owner, name="Corte", duration_minutes=60, price_eur="20.00",
+    )
+    return tenant, owner, professional, service
+
+
+@pytest.mark.django_db
+class TestAutoSlotCreation:
+    def setup_method(self):
+        self.client = APIClient()
+
+    def test_auto_slot_creates_appointment_and_slot(self):
+        tenant, owner, professional, service = _make_setup("as-basic")
+        self.client.force_authenticate(user=owner)
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+            "start_time": FUTURE_START.isoformat(),
+            "end_time": FUTURE_END.isoformat(),
+        }, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert Appointment.objects.filter(tenant=tenant).count() == 1
+        assert ScheduleSlot.objects.filter(tenant=tenant, professional=professional).count() == 1
+        slot = ScheduleSlot.objects.get(tenant=tenant, professional=professional)
+        assert slot.status == "booked"
+        assert not slot.is_available
+
+    def test_auto_slot_reuses_existing_available_slot(self):
+        tenant, owner, professional, service = _make_setup("as-reuse")
+        existing_slot = ScheduleSlot.objects.create(
+            tenant=tenant, professional=professional,
+            start_time=FUTURE_START, end_time=FUTURE_END,
+            is_available=True, status="available",
+        )
+        self.client.force_authenticate(user=owner)
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+            "start_time": FUTURE_START.isoformat(),
+            "end_time": FUTURE_END.isoformat(),
+        }, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert ScheduleSlot.objects.filter(tenant=tenant, professional=professional).count() == 1
+        existing_slot.refresh_from_db()
+        assert existing_slot.status == "booked"
+
+    def test_traditional_slot_id_still_works(self):
+        tenant, owner, professional, service = _make_setup("as-trad")
+        slot = ScheduleSlot.objects.create(
+            tenant=tenant, professional=professional,
+            start_time=FUTURE_START, end_time=FUTURE_END,
+            is_available=True, status="available",
+        )
+        self.client.force_authenticate(user=owner)
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+            "slot": slot.id,
+        }, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED
+        slot.refresh_from_db()
+        assert slot.status == "booked"
+
+
+@pytest.mark.django_db
+class TestAutoSlotValidation:
+    def setup_method(self):
+        self.client = APIClient()
+
+    def test_missing_start_time_returns_error(self):
+        _tenant, owner, professional, service = _make_setup("as-val-nostart")
+        self.client.force_authenticate(user=owner)
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+            "end_time": FUTURE_END.isoformat(),
+        }, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_missing_end_time_returns_error(self):
+        _tenant, owner, professional, service = _make_setup("as-val-noend")
+        self.client.force_authenticate(user=owner)
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+            "start_time": FUTURE_START.isoformat(),
+        }, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_end_before_start_returns_error(self):
+        _tenant, owner, professional, service = _make_setup("as-val-endbeforestart")
+        self.client.force_authenticate(user=owner)
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+            "start_time": FUTURE_END.isoformat(),
+            "end_time": FUTURE_START.isoformat(),
+        }, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_past_start_time_returns_error(self):
+        _tenant, owner, professional, service = _make_setup("as-val-past")
+        past = timezone.now() - timedelta(hours=1)
+        self.client.force_authenticate(user=owner)
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+            "start_time": past.isoformat(),
+            "end_time": (past + timedelta(hours=1)).isoformat(),
+        }, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_overlap_with_booked_slot_returns_error(self):
+        tenant, owner, professional, service = _make_setup("as-val-overlap")
+        ScheduleSlot.objects.create(
+            tenant=tenant, professional=professional,
+            start_time=FUTURE_START, end_time=FUTURE_END,
+            is_available=False, status="booked",
+        )
+        self.client.force_authenticate(user=owner)
+        # Tenta agendar no mesmo horário
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+            "start_time": FUTURE_START.isoformat(),
+            "end_time": FUTURE_END.isoformat(),
+        }, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_no_slot_no_times_returns_error(self):
+        _tenant, owner, professional, service = _make_setup("as-val-nothing")
+        self.client.force_authenticate(user=owner)
+        resp = self.client.post(URL, {
+            "professional": professional.id,
+            "service": service.id,
+        }, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/core/views.py
+++ b/core/views.py
@@ -578,19 +578,35 @@ class AppointmentCreateView(TenantIsolatedMixin, CreateAPIView):
 
     def perform_create(self, serializer):
         data = cast(Dict[str, Any], serializer.validated_data)
-        slot = data["slot"]
-        if (not slot.is_available) or (slot.status != "available"):
-            raise ValidationError(
-                "Este horário já foi agendado ou não está disponível."
+        slot = data.get("slot")
+        tenant = getattr(self.request, "tenant", None) or getattr(
+            self.request.user, "tenant", None
+        )
+
+        if slot is None:
+            # Auto-criação de slot a partir de start_time / end_time / professional
+            professional = data["professional"]
+            start_time = data.pop("start_time")
+            end_time = data.pop("end_time")
+            slot, created = ScheduleSlot.objects.get_or_create(
+                professional=professional,
+                start_time=start_time,
+                defaults={"end_time": end_time, "tenant": tenant, "is_available": True, "status": "available"},
             )
+            if not created and (not slot.is_available or slot.status != "available"):
+                raise ValidationError("Este horário já foi agendado ou não está disponível.")
+            data["slot"] = slot
+        else:
+            data.pop("start_time", None)
+            data.pop("end_time", None)
+            if (not slot.is_available) or (slot.status != "available"):
+                raise ValidationError(
+                    "Este horário já foi agendado ou não está disponível."
+                )
 
         # marca como reservado via helper do model
         slot.mark_booked()
 
-        # Definir tenant e client
-        tenant = getattr(self.request, "tenant", None) or getattr(
-            self.request.user, "tenant", None
-        )
         customer = self._ensure_customer(tenant, data.get("customer"))
 
         save_kwargs: Dict[str, Any] = {"client": self.request.user}


### PR DESCRIPTION
…#458[AppointmentSerializer](vscode-webview://1t01o44qtg549fn09e7i6q9uv1abq4icjp1puerhp8kgee342pq6/salonix-backend/core/serializers.py): slot agora opcional; novos campos write-only start_time e end_time; validação de sobreposição e de campos obrigatórios quando slot ausente
[AppointmentViewSet.perform_create](vscode-webview://1t01o44qtg549fn09e7i6q9uv1abq4icjp1puerhp8kgee342pq6/salonix-backend/core/views.py): auto-criação do slot via get_or_create quando slot não fornecido
[test_appointment_auto_slot.py](vscode-webview://1t01o44qtg549fn09e7i6q9uv1abq4icjp1puerhp8kgee342pq6/salonix-backend/core/tests/test_appointment_auto_slot.py): 9 testes cobrindo os dois caminhos e casos de erro