### PR TITLE
BE-PLANS-01: Bloquear Plano Pro e consolidar features no plano Basic

### DIFF
--- a/docs/PLANOS_BLOQUEIO_PRO.md
+++ b/docs/PLANOS_BLOQUEIO_PRO.md
@@ -1,0 +1,175 @@
+# BE-PLANS-01: Bloqueio do Plano Pro e Consolidação de Features no Basic/Founder
+
+> **Issue:** #481 · **Branch:** `481-be-plans-01` · **Data:** 2026-06-12
+>
+> Coordenar depois com **FEW-PLANS-01** (frontend web) e **MOB-PLANS-01** (mobile).
+
+## Decisão de produto
+
+O plano **Pro foi bloqueado** — invisível e inacessível em qualquer fluxo público —
+mas **preservado no código** para possível reativação futura. Os planos **Basic e
+Founder absorveram todas as features** que eram exclusivas do Pro, tornando o Basic
+o plano comercial principal.
+
+Pontos importantes do escopo (esclarecidos em conjunto com o produto):
+
+- A absorção é **apenas de features**. Preços e créditos de comunicação **não mudam**:
+
+  | Plano   | Preço mensal | Créditos iniciais |
+  |---------|--------------|-------------------|
+  | Basic   | €29,00       | €5,00             |
+  | Founder | €15,00       | €2,00             |
+  | Pro     | (bloqueado)  | (bloqueado)       |
+
+- O **Founder também recebe** as features ex-Pro. A frase "Founder permanece
+  inalterado" da issue refere-se a preço, créditos e condições comerciais.
+- Permissões de papel (Tenant/Owner, Manager, Staff) **não mudaram**.
+
+## Features ex-Pro absorvidas por Basic e Founder
+
+- Relatórios avançados (Business Analysis + Insights, Top Services, Revenue, Retention).
+- White-label.
+- Domínio personalizado (continua dependendo da flag `custom_domain_enabled`).
+- Apps nativos Admin e Client (React Native).
+- Push mobile.
+- Notificações avançadas (SMS/WhatsApp) por plano — antes exigiam Pro ou créditos extras.
+- Auto-renovação de créditos de comunicação (feature liberada; valores não mudam).
+- Retenção pós-cancelamento de 90 dias (Basic tinha 30; Founder já tinha 90).
+- Exports assíncronos de relatórios do tipo `advanced`.
+
+## Como o bloqueio funciona
+
+### Fonte única de verdade
+
+`users/models.py` — classe `Tenant`:
+
+```python
+BLOCKED_PLANS = [PLAN_PRO]
+
+@classmethod
+def is_plan_blocked(cls, plan_code) -> bool: ...
+```
+
+O Pro **permanece** em `PLAN_CHOICES` (dados históricos e reativação futura), mas
+nenhum fluxo público o lista ou atribui. Para reativar o Pro no futuro, basta
+remover o código de `BLOCKED_PLANS` e revisar os pontos listados abaixo.
+
+### Pontos de aplicação
+
+| Camada | Arquivo | Comportamento |
+|---|---|---|
+| Listagem pública de planos | `payments/services.py` (`get_available_plans`) | Planos bloqueados são filtrados do `plan_order`; nunca chegam ao frontend |
+| Checkout (serializer v2) | `payments/serializers.py` (`validate_plan`) | `plan="pro"` → HTTP 400 "Este plano não está disponível no momento." |
+| Checkout (view legada) | `payments/views.py` (`CreateCheckoutSession`) | `allowed_plans = {"basic", "founder"}` → HTTP 400 |
+| Webhooks Stripe | `payments/views.py` (3 pontos) e `payments/webhooks.py` (2 pontos) | Evento residual com plano bloqueado **não** altera `plan_tier`; loga `warning` com tenant e plano — sem erro silencioso |
+| Billing overview | `payments/views.py` (`BillingOverviewView`) | Sync de plano em GET nunca aplica plano bloqueado |
+| Conversão promocional | `users/models.py` (`apply_promotional_transition`) | Se `promotional_converts_to_plan` for bloqueado, converte para Basic |
+| Console OPS | `ops/serializers.py` (`OpsTenantPlanUpdateSerializer`) | `plan_tier="pro"` rejeitado com erro de validação |
+| Django Admin | `users/admin.py` | Ver seção abaixo |
+| Créditos iniciais | `users/signals.py` (sem alteração) | Pro fora de `get_available_plans` → tenant criado como Pro não recebe crédito inicial |
+
+### Tenants legados em Pro
+
+Tenants que ainda estejam com `plan_tier="pro"` (em produção, 2 contas de teste)
+**continuam funcionando** — os métodos de gating incluem o Pro nas listas de planos
+permitidos. A migração é feita explicitamente pelo management command (abaixo).
+
+## Mudanças de gating (`users/models.py` e `users/feature_flags.py`)
+
+Métodos do `Tenant` atualizados para `plan_tier in [PLAN_BASIC, PLAN_PRO, PLAN_FOUNDER]`:
+
+- `can_use_advanced_reports()` — antes só Pro.
+- `can_use_white_label()` — antes só Pro.
+- `can_use_custom_domain()` — antes Pro + flag; agora qualquer plano ativo + flag.
+- `can_use_native_admin()` / `can_use_native_client()` — antes Pro ou flag explícita.
+- `can_use_advanced_notifications()` — antes Pro (ou canal + créditos extras).
+- `can_use_pwa_client()` — agora inclui `PLAN_FOUNDER` na lista (correção de lacuna).
+- `get_retention_days()` — Basic: 30 → **90 dias**.
+
+Em `users/feature_flags.py`, a `plan_hierarchy` usada por `requires_plan()` /
+`RequiresPlan` foi nivelada (todos os planos ativos no nível 2). De passagem,
+**corrigido um bug**: `founder` não existia na hierarquia e caía para nível 0 —
+um tenant Founder falharia qualquer `requires_plan('pro')`.
+
+Em `users/views.py`, o toggle de `push_mobile_enabled` deixou de exigir Pro
+(passa a aceitar qualquer plano ativo).
+
+Em `ops/views.py` (`update_plan`), a lógica de conflitos "planos não-Pro não
+suportam SMS/WhatsApp/addons" foi removida — todos os planos ativos suportam;
+mudanças de plano não desativam mais esses recursos.
+
+`get_feature_flags_dict()` não precisou de alteração: ele delega aos métodos
+`can_use_*`, então o payload exposto ao frontend reflete automaticamente as
+novas capacidades.
+
+## Migração dos tenants (management command)
+
+```bash
+python manage.py migrate_tenants_to_basic --dry-run   # lista sem alterar
+python manage.py migrate_tenants_to_basic             # executa
+```
+
+Arquivo: `users/management/commands/migrate_tenants_to_basic.py`
+
+- Seleciona tenants com `plan_tier` em `BLOCKED_PLANS` (Founder não é tocado).
+- **Idempotente**: re-execuções não alteram tenants já migrados ("Nada a migrar").
+- Transação atômica com `select_for_update`; log estruturado por tenant
+  (`tenant_id`, plano antigo → novo) + saída legível no stdout.
+
+Após o deploy desta tarefa, rodar o command em produção para migrar as 2 contas
+de teste.
+
+## Django Admin (`users/admin.py`)
+
+- Ação em massa **"Upgrade para plano Pro" removida**.
+- `plan_tier` e `promotional_converts_to_plan`: choices filtrados via
+  `formfield_for_choice_field` — Pro não aparece ao criar/editar tenant
+  (registros históricos mantêm o valor salvo).
+- Filtro lateral de plano substituído por `PlanTierListFilter` (custom), que
+  oculta planos bloqueados das opções.
+
+## Testes
+
+Suite completa: **906 passed, 5 skipped** (`python -m pytest`).
+
+### Novos (`users/tests/test_plan_blocking.py`, 17 testes)
+
+- Pro bloqueado / Basic e Founder não bloqueados.
+- Pro ausente de `get_available_plans()`.
+- Checkout com `plan="pro"` rejeitado (view legada e v2).
+- Conversão promocional nunca resulta em plano bloqueado.
+- Basic e Founder com todas as features ex-Pro; retenção 90 dias.
+- Domínio custom continua exigindo flag.
+- Owner Basic consegue ativar auto-renovação de créditos.
+- Preço/créditos do Basic inalterados (€29/€5).
+- OPS rejeita Pro e aceita Basic.
+- Command: migra Pro→Basic, não toca Founder, idempotente, `--dry-run` não altera.
+
+### Atualizados (~25 testes em 13 arquivos)
+
+Testes que assumiam o gating antigo foram invertidos (Basic agora tem acesso) ou
+adaptados. Destaques:
+
+- **Cobertura do caminho de negação preservada**: como nenhum plano ativo é mais
+  negado nos apps mobile, os testes do payload 403 (`PLAN_UPGRADE_REQUIRED`) em
+  `users/tests/test_permissions.py` e `test_mobile_app_access.py` passaram a
+  mockar `Tenant.can_use_native_admin/client` — a máquina de negação continua
+  testada sem depender de um plano negado real.
+- `test_pro_plan_initial_credits`: tenant criado como Pro **não recebe** crédito
+  inicial (consequência do signal usar `get_available_plans`); documentado no teste.
+- Cancelamento: fixtures ajustadas para a retenção de 90 dias do Basic.
+- OPS: troca de plano não gera mais conflito 409; upgrade de teste usa Founder.
+
+### Nota sobre o conftest global
+
+O tenant default dos testes (`conftest.py`, `setup_default_tenant`) usa
+`plan_tier="pro"` — mantido de propósito: valida que tenants legados em Pro
+continuam operando normalmente até a migração.
+
+## Reativação futura do Pro (checklist)
+
+1. Remover `PLAN_PRO` de `Tenant.BLOCKED_PLANS`.
+2. Reavaliar `AVAILABLE_PLANS["pro"]` (preço/features/créditos) em `payments/services.py`.
+3. Decidir se as features voltam a ser exclusivas (reverter listas nos `can_use_*`).
+4. Restaurar choices/filtros no Django Admin se desejado.
+5. Revisar testes de `test_plan_blocking.py` (vão falhar apontando os pontos).

--- a/notifications/tests/test_views.py
+++ b/notifications/tests/test_views.py
@@ -280,10 +280,10 @@ class TestNotificationViews:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_notification_list_admin_app_denied_for_basic_tenant(
+    def test_notification_list_admin_app_allowed_for_basic_tenant(
         self, tenant_fixture, user_fixture
     ):
-        """Tenant Basic não deve acessar notificações pelo Admin App."""
+        """BE-PLANS-01 (#481): Basic absorveu apps nativos; Admin App liberado."""
         tenant_fixture.plan_tier = "basic"
         tenant_fixture.rn_admin_enabled = False
         tenant_fixture.save(
@@ -294,11 +294,7 @@ class TestNotificationViews:
         url = reverse("notification-list")
         response = self.client.get(url, HTTP_X_APP_TYPE="admin")
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.data["error"]["code"] == "E004"
-        assert response.data["error"]["details"]["code"] == "PLAN_UPGRADE_REQUIRED"
-        assert response.data["error"]["details"]["current_plan"] == "basic"
-        assert "Admin App" in response.data["error"]["message"]
+        assert response.status_code == status.HTTP_200_OK
 
     def test_register_device_client_app_allowed_for_pro_tenant(
         self, tenant_fixture, user_fixture
@@ -319,10 +315,10 @@ class TestNotificationViews:
         assert response.data["device_type"] == "mobile"
         assert response.data["token"] == "test-mobile-token-allowed"
 
-    def test_register_device_client_app_denied_for_basic_tenant(
+    def test_register_device_client_app_allowed_for_basic_tenant(
         self, tenant_fixture, user_fixture
     ):
-        """Tenant Basic não deve registrar device com X-App-Type: client."""
+        """BE-PLANS-01 (#481): Basic absorveu apps nativos; Client App liberado."""
         tenant_fixture.plan_tier = "basic"
         tenant_fixture.rn_client_enabled = False
         tenant_fixture.save(
@@ -334,14 +330,10 @@ class TestNotificationViews:
         url = reverse("notification-register-device")
         data = {
             "device_type": "mobile",
-            "token": "test-mobile-token-denied",
+            "token": "test-mobile-token-now-allowed",
             "is_active": True,
         }
 
         response = self.client.post(url, data, HTTP_X_APP_TYPE="client")
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.data["error"]["code"] == "E004"
-        assert response.data["error"]["details"]["code"] == "PLAN_UPGRADE_REQUIRED"
-        assert response.data["error"]["details"]["current_plan"] == "basic"
-        assert "Client App" in response.data["error"]["message"]
+        assert response.status_code == status.HTTP_201_CREATED

--- a/ops/serializers.py
+++ b/ops/serializers.py
@@ -356,6 +356,14 @@ class OpsTenantPlanUpdateSerializer(serializers.Serializer):
     addons_enabled = serializers.JSONField(required=False)
     force = serializers.BooleanField(required=False, default=False)
 
+    def validate_plan_tier(self, value):
+        # BE-PLANS-01 (#481): plano bloqueado não pode ser atribuído nem via OPS.
+        if Tenant.is_plan_blocked(value):
+            raise serializers.ValidationError(
+                "Este plano está bloqueado e não pode ser atribuído."
+            )
+        return value
+
 
 class OpsAlertSerializer(serializers.ModelSerializer):
     tenant_name = serializers.CharField(source="tenant.name", read_only=True)

--- a/ops/tests/test_ops_tenants.py
+++ b/ops/tests/test_ops_tenants.py
@@ -166,28 +166,21 @@ class TestOpsTenantsEndpoints:
         access = ops_authenticate(admin.email)
         url = reverse("ops-tenants-update-plan", kwargs={"pk": tenant.id})
 
+        # BE-PLANS-01 (#481): todos os planos ativos suportam SMS/WhatsApp/addons;
+        # a mudança de plano não gera mais conflitos nem exige force.
         response = api_client.post(
             url,
             {"plan_tier": Tenant.PLAN_BASIC},
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {access}",
         )
-        assert response.status_code == status.HTTP_409_CONFLICT
-        assert "conflicts" in response.data
-        assert len(response.data["conflicts"]) > 0
-
-        response = api_client.post(
-            url,
-            {"plan_tier": Tenant.PLAN_BASIC, "force": True},
-            format="json",
-            HTTP_AUTHORIZATION=f"Bearer {access}",
-        )
         assert response.status_code == status.HTTP_200_OK
         tenant.refresh_from_db()
         assert tenant.plan_tier == Tenant.PLAN_BASIC
-        assert tenant.sms_enabled is False
-        assert tenant.whatsapp_enabled is False
-        assert "rn_admin" not in (tenant.addons_enabled or [])
+        # Features absorvidas permanecem habilitadas após a mudança de plano
+        assert tenant.sms_enabled is True
+        assert tenant.whatsapp_enabled is True
+        assert "rn_admin" in (tenant.addons_enabled or [])
 
     def test_plan_downgrade_invalidates_tenant_sessions_only(
         self,
@@ -279,9 +272,10 @@ class TestOpsTenantsEndpoints:
 
         access = ops_authenticate(admin.email)
         url = reverse("ops-tenants-update-plan", kwargs={"pk": tenant.id})
+        # BE-PLANS-01 (#481): Pro bloqueado; upgrade de teste passa a usar Founder.
         response = api_client.post(
             url,
-            {"plan_tier": Tenant.PLAN_PRO},
+            {"plan_tier": Tenant.PLAN_FOUNDER},
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {access}",
         )

--- a/ops/views.py
+++ b/ops/views.py
@@ -412,15 +412,9 @@ class OpsTenantViewSet(viewsets.ReadOnlyModelViewSet):
         force = serializer.validated_data.get("force", False)
 
         # Check conflicts
+        # BE-PLANS-01 (#481): todos os planos ativos suportam SMS/WhatsApp/addons
+        # (features ex-Pro absorvidas); não há mais conflitos de recursos entre planos.
         conflicts = []
-        if new_plan != Tenant.PLAN_PRO:
-            # Non-Pro plans don't support SMS/Whatsapp/Addons
-            if tenant.sms_enabled:
-                conflicts.append("sms_enabled")
-            if tenant.whatsapp_enabled:
-                conflicts.append("whatsapp_enabled")
-            if tenant.addons_enabled:
-                conflicts.extend(tenant.addons_enabled)
 
         # Add more logic for other plan transitions if needed
 

--- a/payments/serializers.py
+++ b/payments/serializers.py
@@ -8,6 +8,16 @@ class CheckoutSessionRequestSerializer(serializers.Serializer):
         required=False,
         help_text="Plano desejado",
     )
+
+    def validate_plan(self, value):
+        # BE-PLANS-01 (#481): plano Pro bloqueado para novas subscrições.
+        from users.models import Tenant
+
+        if value in Tenant.BLOCKED_PLANS:
+            raise serializers.ValidationError(
+                "Este plano não está disponível no momento."
+            )
+        return value
     interval = serializers.ChoiceField(
         choices=["monthly", "annual"],
         required=False,

--- a/payments/services.py
+++ b/payments/services.py
@@ -227,14 +227,20 @@ class SubscriptionService:
     """Serviço para gerenciar assinaturas Stripe."""
 
     # Definição dos planos disponíveis
+    # BE-PLANS-01 (#481): o Basic absorveu as features que eram exclusivas do Pro
+    # (preço e créditos inalterados). O Pro permanece definido apenas como
+    # referência histórica/reativação futura — está em Tenant.BLOCKED_PLANS e não
+    # aparece em listagens públicas nem pode ser contratado.
     AVAILABLE_PLANS = {
         "basic": {
             "name": "Basic",
             "price_monthly": Decimal("29.00"),
             "features": [
                 "PWA Admin/Manager/Staff/Client",
-                "Relatórios básicos (Overview)",
-                "Email e web push",
+                "Apps Nativos (Admin/Staff/Client)",
+                "Relatórios completos (Overview + Business + Insights)",
+                "White‑label e Domínio personalizado",
+                "Email, web push e notificações avançadas (SMS/WhatsApp)",
             ],
             "credits_included": Decimal("5.00"),
             "comm_extra_allowed": True,
@@ -272,7 +278,10 @@ class SubscriptionService:
         from users.services import FounderService
 
         plans = []
-        plan_order = ["basic", "pro"]
+        # BE-PLANS-01 (#481): planos bloqueados não aparecem na listagem pública.
+        plan_order = [
+            code for code in ["basic", "pro"] if not Tenant.is_plan_blocked(code)
+        ]
         current_index = (
             plan_order.index(current_plan) if current_plan in plan_order else -1
         )
@@ -321,8 +330,13 @@ class SubscriptionService:
                 },
             )
 
-        print(
-            f"[get_available_plans] tenant={tenant}, founder_available={founder_available}, plans={[p['plan_code'] for p in plans]}"
+        logger.debug(
+            "get_available_plans resolved",
+            extra={
+                "tenant_id": getattr(tenant, "id", None),
+                "founder_available": founder_available,
+                "plans": [p["plan_code"] for p in plans],
+            },
         )
         return plans
 

--- a/payments/tests/test_checkout_trial.py
+++ b/payments/tests/test_checkout_trial.py
@@ -9,7 +9,9 @@ from payments.models import Subscription, PaymentCustomer
 
 @override_settings(
     STRIPE_TRIAL_PERIOD_DAYS=14,
-    STRIPE_PRICE_PRO_MONTHLY_ID="price_pro_test",
+    # BE-PLANS-01 (#481): checkout de teste usa Basic (Pro bloqueado);
+    # override garante o price ID independente do ambiente (CI não tem .env).
+    STRIPE_PRICE_BASIC_MONTHLY_ID="price_basic_test",
 )
 class CheckoutTrialTestCase(APITestCase):
     def setUp(self):

--- a/payments/tests/test_checkout_trial.py
+++ b/payments/tests/test_checkout_trial.py
@@ -55,7 +55,7 @@ class CheckoutTrialTestCase(APITestCase):
 
     def test_new_customer_gets_trial(self):
         """User with no subscription history should get trial days."""
-        response = self.client.post(self.url, {"plan": "pro"})
+        response = self.client.post(self.url, {"plan": "basic"})
         self.assertEqual(response.status_code, 200)
 
         # Check call args
@@ -69,7 +69,7 @@ class CheckoutTrialTestCase(APITestCase):
             user=self.user, stripe_subscription_id="sub_active", status="active"
         )
 
-        response = self.client.post(self.url, {"plan": "pro"})
+        response = self.client.post(self.url, {"plan": "basic"})
         self.assertEqual(response.status_code, 200)
 
         _, kwargs = self.mock_stripe.checkout.Session.create.call_args
@@ -83,7 +83,7 @@ class CheckoutTrialTestCase(APITestCase):
             user=self.user, stripe_subscription_id="sub_canceled", status="canceled"
         )
 
-        response = self.client.post(self.url, {"plan": "pro"})
+        response = self.client.post(self.url, {"plan": "basic"})
         self.assertEqual(response.status_code, 200)
 
         _, kwargs = self.mock_stripe.checkout.Session.create.call_args
@@ -96,7 +96,7 @@ class CheckoutTrialTestCase(APITestCase):
             user=self.user, stripe_subscription_id="sub_incomplete", status="incomplete"
         )
 
-        response = self.client.post(self.url, {"plan": "pro"})
+        response = self.client.post(self.url, {"plan": "basic"})
         self.assertEqual(response.status_code, 200)
 
         _, kwargs = self.mock_stripe.checkout.Session.create.call_args

--- a/payments/tests/test_payments_stripe.py
+++ b/payments/tests/test_payments_stripe.py
@@ -146,6 +146,7 @@ def test_checkout_trial_suppressed_for_existing_subscription(
 ):
     settings.STRIPE_API_KEY = "sk_test_xxx"
     settings.STRIPE_PRICE_PRO_MONTHLY_ID = "price_pro_123"
+    settings.STRIPE_PRICE_BASIC_MONTHLY_ID = "price_basic_123"
     settings.STRIPE_TRIAL_PERIOD_DAYS = 14
     settings.FRONTEND_BASE_URL = "http://localhost:5173"
     settings.STRIPE_API_VERSION = "2024-06-20"
@@ -174,11 +175,11 @@ def test_checkout_trial_suppressed_for_existing_subscription(
     )
 
     url = "/api/payments/stripe/create-checkout-session/"
-    resp = c.post(url, {"plan": "pro"}, format="json")
+    resp = c.post(url, {"plan": "basic"}, format="json")
     assert resp.status_code == 200
 
     created_kwargs = _StripeCheckoutSession.last_kwargs
-    assert created_kwargs["line_items"][0]["price"] == "price_pro_123"
+    assert created_kwargs["line_items"][0]["price"] == "price_basic_123"
     assert "trial_period_days" not in created_kwargs["subscription_data"]
 
 
@@ -188,6 +189,7 @@ def test_checkout_trial_suppressed_for_other_user_in_same_tenant(
 ):
     settings.STRIPE_API_KEY = "sk_test_xxx"
     settings.STRIPE_PRICE_PRO_MONTHLY_ID = "price_pro_123"
+    settings.STRIPE_PRICE_BASIC_MONTHLY_ID = "price_basic_123"
     settings.STRIPE_TRIAL_PERIOD_DAYS = 14
     settings.FRONTEND_BASE_URL = "http://localhost:5173"
     settings.STRIPE_API_VERSION = "2024-06-20"
@@ -223,11 +225,11 @@ def test_checkout_trial_suppressed_for_other_user_in_same_tenant(
     )
 
     url = "/api/payments/stripe/create-checkout-session/"
-    resp = c.post(url, {"plan": "pro"}, format="json")
+    resp = c.post(url, {"plan": "basic"}, format="json")
     assert resp.status_code == 200
 
     created_kwargs = _StripeCheckoutSession.last_kwargs
-    assert created_kwargs["line_items"][0]["price"] == "price_pro_123"
+    assert created_kwargs["line_items"][0]["price"] == "price_basic_123"
     assert "trial_period_days" not in created_kwargs["subscription_data"]
     assert created_kwargs["subscription_data"].get("trial_from_plan") is False
 
@@ -236,6 +238,7 @@ def test_checkout_trial_suppressed_for_other_user_in_same_tenant(
 def test_checkout_trial_applied_for_new_customer(monkeypatch, settings, auth_client):
     settings.STRIPE_API_KEY = "sk_test_xxx"
     settings.STRIPE_PRICE_PRO_MONTHLY_ID = "price_pro_123"
+    settings.STRIPE_PRICE_BASIC_MONTHLY_ID = "price_basic_123"
     settings.STRIPE_TRIAL_PERIOD_DAYS = 14
     settings.FRONTEND_BASE_URL = "http://localhost:5173"
     settings.STRIPE_API_VERSION = "2024-06-20"
@@ -257,11 +260,11 @@ def test_checkout_trial_applied_for_new_customer(monkeypatch, settings, auth_cli
         status=TenantStaffMember.Status.ACTIVE,
     )
     url = "/api/payments/stripe/create-checkout-session/"
-    resp = c.post(url, {"plan": "pro"}, format="json")
+    resp = c.post(url, {"plan": "basic"}, format="json")
     assert resp.status_code == 200
 
     created_kwargs = _StripeCheckoutSession.last_kwargs
-    assert created_kwargs["line_items"][0]["price"] == "price_pro_123"
+    assert created_kwargs["line_items"][0]["price"] == "price_basic_123"
     assert created_kwargs["subscription_data"].get("trial_period_days") == 14
 
 
@@ -466,6 +469,7 @@ def test_webhook_checkout_session_completed_creates_subscription(
     settings.STRIPE_WEBHOOK_SECRET = "whsec_test"
     settings.STRIPE_API_VERSION = "2024-06-20"
     settings.STRIPE_PRICE_PRO_MONTHLY_ID = "price_pro_123"
+    settings.STRIPE_PRICE_BASIC_MONTHLY_ID = "price_basic_123"
 
     # constrói customer local
     c, user = auth_client()
@@ -550,6 +554,7 @@ def test_webhook_checkout_session_completed_creates_subscription(
 def test_checkout_requires_owner_role(monkeypatch, settings):
     settings.STRIPE_API_KEY = "sk_test_xxx"
     settings.STRIPE_PRICE_PRO_MONTHLY_ID = "price_pro_123"
+    settings.STRIPE_PRICE_BASIC_MONTHLY_ID = "price_basic_123"
     settings.STRIPE_TRIAL_PERIOD_DAYS = 14
     settings.FRONTEND_BASE_URL = "http://localhost:5173"
     settings.STRIPE_API_VERSION = "2024-06-20"
@@ -579,7 +584,7 @@ def test_checkout_requires_owner_role(monkeypatch, settings):
     c.force_authenticate(user=user)
 
     url = "/api/payments/stripe/create-checkout-session/"
-    resp = c.post(url, {"plan": "pro"}, format="json")
+    resp = c.post(url, {"plan": "basic"}, format="json")
     assert resp.status_code == 403
     assert "OWNER ativo" in _error_message(resp)
 
@@ -629,6 +634,7 @@ def test_webhook_invoice_payment_succeeded_applies_included_credits(
     settings.STRIPE_WEBHOOK_SECRET = "whsec_test"
     settings.STRIPE_API_VERSION = "2024-06-20"
     settings.STRIPE_PRICE_PRO_MONTHLY_ID = "price_pro_123"
+    settings.STRIPE_PRICE_BASIC_MONTHLY_ID = "price_basic_123"
 
     from payments import views as payments_views
     from payments import stripe_utils as payments_stripe_utils
@@ -741,9 +747,8 @@ def test_get_available_plans_returns_correct_auto_renew_and_credits(monkeypatch)
     assert basic_plan["comm_auto_renew"] is False
     assert basic_plan["credits_included"] == 5
 
-    assert pro_plan is not None
-    assert pro_plan["comm_auto_renew"] is True
-    assert pro_plan["credits_included"] == 15
+    # BE-PLANS-01 (#481): Pro bloqueado não aparece na listagem pública
+    assert pro_plan is None
 
     assert founder_plan is not None
     assert founder_plan["comm_auto_renew"] is False

--- a/payments/views.py
+++ b/payments/views.py
@@ -91,9 +91,9 @@ class CreateCheckoutSession(APIView):
         requested_plan = (request.data.get("plan") or "basic").lower()
         requested_interval = (request.data.get("interval") or "monthly").lower()
 
+        # BE-PLANS-01 (#481): plano Pro bloqueado para novas subscrições.
         allowed_plans = {
             "basic",
-            "pro",
             "founder",
         }
 
@@ -430,6 +430,19 @@ class StripeWebhookView(APIView):
                         else getattr(tenant, "PLAN_BASIC", "basic")
                     )
 
+                # BE-PLANS-01 (#481): evento residual de plano bloqueado (ex: Pro)
+                # não pode reativar o plano — loga e mantém o plano atual.
+                if desired_plan and Tenant.is_plan_blocked(desired_plan):
+                    logger.warning(
+                        "Blocked plan received from Stripe event; keeping current plan",
+                        extra={
+                            "tenant_id": tenant.id,
+                            "blocked_plan": desired_plan,
+                            "current_plan": tenant.plan_tier,
+                        },
+                    )
+                    desired_plan = None
+
                 if desired_plan and tenant.plan_tier != desired_plan:
                     old_plan = tenant.plan_tier
                     tenant.plan_tier = desired_plan
@@ -624,7 +637,16 @@ class StripeWebhookView(APIView):
                                             f"[WEBHOOK] Tenant {tenant.slug} promoted to Founder."
                                         )
 
-                                if tenant.plan_tier != target_tier:
+                                # BE-PLANS-01 (#481): nunca sincronizar para plano bloqueado.
+                                if Tenant.is_plan_blocked(target_tier):
+                                    logger.warning(
+                                        "[WEBHOOK] Blocked plan in metadata; keeping current plan",
+                                        extra={
+                                            "tenant_id": tenant.id,
+                                            "blocked_plan": target_tier,
+                                        },
+                                    )
+                                elif tenant.plan_tier != target_tier:
                                     logger.info(
                                         f"[WEBHOOK] Forcing tenant plan update: {tenant.plan_tier} -> {target_tier}"
                                     )
@@ -1392,7 +1414,13 @@ class BillingOverviewView(APIView):
                 tenant = getattr(request.user, "tenant", None)
                 current = overview.get("current_subscription") or {}
                 plan_code = current.get("plan_code")
-                if tenant and plan_code and tenant.plan_tier != plan_code:
+                # BE-PLANS-01 (#481): nunca sincronizar para plano bloqueado.
+                if (
+                    tenant
+                    and plan_code
+                    and tenant.plan_tier != plan_code
+                    and not Tenant.is_plan_blocked(plan_code)
+                ):
                     old = tenant.plan_tier
                     tenant.plan_tier = plan_code
                     tenant.save(update_fields=["plan_tier", "updated_at"])
@@ -1527,13 +1555,8 @@ class StripeSettingsView(APIView):
         auto_renewal = serializer.validated_data["auto_renewal"]
         old_value = bool(getattr(tenant, "comm_auto_renew", False))
 
-        # Validar plano para habilitar auto-renovação (Pro+)
-        if auto_renewal and tenant.plan_tier != Tenant.PLAN_PRO:
-            PAYMENTS_SETTINGS_UPDATED_TOTAL.labels(result="forbidden").inc()
-            return Response(
-                {"detail": "Renovação automática disponível apenas em planos Pro"},
-                status=403,
-            )
+        # BE-PLANS-01 (#481): auto-renovação era exclusiva do Pro; feature absorvida
+        # por todos os planos ativos (valores de créditos não mudam).
 
         try:
             setattr(tenant, "comm_auto_renew", auto_renewal)

--- a/payments/webhooks.py
+++ b/payments/webhooks.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from decimal import Decimal
 
 from .models import CreditPayment, StripeWebhookEvent, PaymentCustomer, Subscription
+from users.models import Tenant
 from users.services import CreditService
 from . import stripe_utils
 
@@ -248,8 +249,14 @@ class StripeWebhookView(View):
                 flags.save()
 
                 # Atualizar tenant plan_tier
+                # BE-PLANS-01 (#481): nunca atribuir plano bloqueado via webhook.
                 tenant = payment_customer.user.tenant
-                if tenant:
+                if tenant and Tenant.is_plan_blocked(plan_code):
+                    logger.warning(
+                        "Blocked plan from Stripe webhook ignored",
+                        extra={"tenant_id": tenant.id, "blocked_plan": plan_code},
+                    )
+                elif tenant:
                     tenant.plan_tier = plan_code
                     tenant.save()
 
@@ -310,8 +317,14 @@ class StripeWebhookView(View):
                 flags.pro_plan = "pro" if flags.is_pro else None
                 flags.save()
 
+                # BE-PLANS-01 (#481): nunca atribuir plano bloqueado via webhook.
                 tenant = payment_customer.user.tenant
-                if tenant:
+                if tenant and Tenant.is_plan_blocked(plan_code):
+                    logger.warning(
+                        "Blocked plan from Stripe webhook ignored",
+                        extra={"tenant_id": tenant.id, "blocked_plan": plan_code},
+                    )
+                elif tenant:
                     tenant.plan_tier = plan_code
                     tenant.save()
 

--- a/reports/tests/test_async_export.py
+++ b/reports/tests/test_async_export.py
@@ -81,12 +81,13 @@ def test_create_job_invalid_type_returns_400():
 
 
 @pytest.mark.django_db
-def test_create_job_pro_only_type_denied_for_basic_tenant():
+def test_create_job_advanced_type_allowed_for_basic_tenant():
+    # BE-PLANS-01 (#481): Basic absorveu relatórios avançados (ex-Pro).
     tenant = _make_tenant(plan=Tenant.PLAN_BASIC)
     user = _make_user(tenant, is_pro=False)
     with patch("reports.views_export.generate_csv_export.delay"):
         r = _client(user).post("/api/reports/exports/", {"report_type": "advanced"}, format="json")
-    assert r.status_code == 403
+    assert r.status_code == 202
 
 
 @pytest.mark.django_db

--- a/reports/tests/test_reports.py
+++ b/reports/tests/test_reports.py
@@ -373,13 +373,14 @@ def test_reports_permissions_by_plan():
     r = c.get("/api/reports/overview/")
     assert r.status_code == 200
 
-    # Top Services -> 403 (Requer Pro)
+    # BE-PLANS-01 (#481): Basic absorveu os relatórios ex-Pro
+    # Top Services -> OK
     r = c.get("/api/reports/top-services/")
-    assert r.status_code == 403
+    assert r.status_code == 200
 
-    # Revenue -> 403 (Requer Pro)
+    # Revenue -> OK
     r = c.get("/api/reports/revenue/")
-    assert r.status_code == 403
+    assert r.status_code == 200
 
 
 @pytest.mark.django_db
@@ -411,11 +412,12 @@ def test_retention_report_permissions_and_data():
     c = APIClient()
     c.force_authenticate(user_basic)
 
+    # BE-PLANS-01 (#481): Basic absorveu retention e advanced (ex-Pro)
     r = c.get("/api/reports/retention/")
-    assert r.status_code == 403
+    assert r.status_code == 200
 
     r = c.get("/api/reports/advanced/")
-    assert r.status_code == 403
+    assert r.status_code == 200
 
     # --- 2. Test Data Logic (Pro User) ---
     tenant_pro = Tenant.objects.create(

--- a/tests/test_business_logging.py
+++ b/tests/test_business_logging.py
@@ -471,7 +471,8 @@ class TestBusinessLogging:
 
     @patch("stripe.Customer.create")
     @patch("stripe.checkout.Session.create")
-    @override_settings(STRIPE_PRICE_PRO_MONTHLY_ID="price_test_pro_123")
+    # BE-PLANS-01 (#481): checkout usa Basic; override garante o price ID no CI.
+    @override_settings(STRIPE_PRICE_BASIC_MONTHLY_ID="price_test_basic_123")
     def test_checkout_session_logs(
         self,
         mock_stripe_session,

--- a/tests/test_business_logging.py
+++ b/tests/test_business_logging.py
@@ -501,7 +501,7 @@ class TestBusinessLogging:
             {"url": "http://checkout.stripe.com", "id": "sess_123"},
         )
 
-        data = {"plan": "pro", "period": "monthly"}
+        data = {"plan": "basic", "period": "monthly"}
 
         caplog.clear()
         with caplog.at_level(logging.INFO, logger="payments.views"):
@@ -519,5 +519,5 @@ class TestBusinessLogging:
         assert len(log_records) > 0
         record = log_records[0]
         assert getattr(record, "tenant_id", None) == tenant.slug
-        assert getattr(record, "plan_code", None) == "pro"
+        assert getattr(record, "plan_code", None) == "basic"
         assert getattr(record, "checkout_url", None) == "http://checkout.stripe.com"

--- a/users/admin.py
+++ b/users/admin.py
@@ -10,6 +10,25 @@ from typing import Any
 from .models import CustomUser, Tenant, UserFeatureFlags, TenantStaffMember, CommLedger
 
 
+class PlanTierListFilter(admin.SimpleListFilter):
+    """Filtro de plano sem os planos bloqueados (BE-PLANS-01 #481)."""
+
+    title = "Plano"
+    parameter_name = "plan_tier"
+
+    def lookups(self, request, model_admin):
+        return [
+            (value, label)
+            for value, label in Tenant.PLAN_CHOICES
+            if not Tenant.is_plan_blocked(value)
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(plan_tier=self.value())
+        return queryset
+
+
 @admin.register(Tenant)
 class TenantAdmin(admin.ModelAdmin):
     """
@@ -28,7 +47,7 @@ class TenantAdmin(admin.ModelAdmin):
         "created_at",
     ]
     list_filter = [
-        "plan_tier",
+        PlanTierListFilter,
         "billing_mode",
         "status",
         "is_active",
@@ -142,6 +161,18 @@ class TenantAdmin(admin.ModelAdmin):
         models.CharField: {"widget": TextInput(attrs={"size": "10"})},
     }
 
+    def formfield_for_choice_field(self, db_field, request, **kwargs):
+        # BE-PLANS-01 (#481): planos bloqueados não aparecem como opção
+        # selecionável ao criar/editar tenant (preservados apenas como
+        # valor histórico em registros existentes).
+        if db_field.name in ("plan_tier", "promotional_converts_to_plan"):
+            kwargs["choices"] = [
+                (value, label)
+                for value, label in db_field.get_choices(include_blank=False)
+                if not Tenant.is_plan_blocked(value)
+            ]
+        return super().formfield_for_choice_field(db_field, request, **kwargs)
+
     def users_count(self, obj):
         """Conta quantos usuários pertencem a este tenant."""
         count = obj.users.count()
@@ -173,7 +204,8 @@ class TenantAdmin(admin.ModelAdmin):
 
     feature_summary.short_description = "Features Ativas"
 
-    actions = ["activate_tenants", "deactivate_tenants", "upgrade_to_pro"]
+    # BE-PLANS-01 (#481): ação "upgrade_to_pro" removida — plano Pro bloqueado.
+    actions = ["activate_tenants", "deactivate_tenants"]
 
     def activate_tenants(self, request, queryset):
         """Ativa tenants selecionados."""
@@ -188,20 +220,6 @@ class TenantAdmin(admin.ModelAdmin):
         self.message_user(request, f"{updated} tenant(s) desativado(s) com sucesso.")
 
     deactivate_tenants.short_description = "Desativar tenants selecionados"
-
-    def upgrade_to_pro(self, request, queryset):
-        """Upgrade para plano Pro com todas as features."""
-        updated = queryset.update(
-            plan_tier=Tenant.PLAN_PRO,
-            reports_enabled=True,
-            pwa_client_enabled=True,
-            push_web_enabled=True,
-            push_mobile_enabled=True,
-        )
-        self.message_user(request, f"{updated} tenant(s) upgradado(s) para Pro.")
-
-    upgrade_to_pro.short_description = "Upgrade para plano Pro"
-
 
 @admin.register(CustomUser)
 class CustomUserAdmin(UserAdmin):

--- a/users/feature_flags.py
+++ b/users/feature_flags.py
@@ -105,10 +105,13 @@ def requires_plan(min_plan, error_message=None):
                 raise PermissionDenied("Usuário não possui tenant associado.")
 
             tenant = request.user.tenant
+            # BE-PLANS-01 (#481): Basic e Founder absorveram as features do Pro;
+            # todos os planos ativos satisfazem qualquer requisito de plano.
             plan_hierarchy = {
-                "basic": 0,
-                "standard": 1,
+                "basic": 2,
+                "standard": 2,
                 "pro": 2,
+                "founder": 2,
             }
 
             current_plan_level = plan_hierarchy.get(tenant.plan_tier, 0)
@@ -149,10 +152,13 @@ class RequiresPlan(BasePermission):
             return False
 
         tenant = request.user.tenant
+        # BE-PLANS-01 (#481): Basic e Founder absorveram as features do Pro;
+        # todos os planos ativos satisfazem qualquer requisito de plano.
         plan_hierarchy = {
-            "basic": 0,
-            "standard": 1,
+            "basic": 2,
+            "standard": 2,
             "pro": 2,
+            "founder": 2,
         }
 
         current_plan_level = plan_hierarchy.get(tenant.plan_tier, 0)

--- a/users/management/commands/migrate_tenants_to_basic.py
+++ b/users/management/commands/migrate_tenants_to_basic.py
@@ -1,0 +1,99 @@
+"""
+Management command para migrar tenants em planos bloqueados para o Basic.
+
+BE-PLANS-01 (#481): o plano Pro foi bloqueado e o Basic absorveu suas features.
+Este comando migra os tenants que ainda estão em planos bloqueados (em produção,
+apenas 2 contas de teste) para o plano Basic. Tenants Founder não são alterados.
+
+Uso:
+    python manage.py migrate_tenants_to_basic            # executa a migração
+    python manage.py migrate_tenants_to_basic --dry-run  # apenas lista, sem alterar
+
+O comando é idempotente: re-execuções não alteram tenants já migrados.
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from users.models import Tenant
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Migra tenants em planos bloqueados (ex: Pro) para o plano Basic "
+        "(BE-PLANS-01 #481). Idempotente; suporta --dry-run."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Lista os tenants que seriam migrados sem alterar nada.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        tenants_to_migrate = Tenant.objects.filter(
+            plan_tier__in=Tenant.BLOCKED_PLANS
+        ).order_by("id")
+
+        total = tenants_to_migrate.count()
+        if total == 0:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Nenhum tenant em plano bloqueado. Nada a migrar."
+                )
+            )
+            return
+
+        self.stdout.write(
+            self.style.WARNING(
+                f"Encontrados {total} tenant(s) em planos bloqueados "
+                f"({', '.join(Tenant.BLOCKED_PLANS)})."
+            )
+        )
+
+        migrated = 0
+        with transaction.atomic():
+            for tenant in tenants_to_migrate.select_for_update():
+                old_plan = tenant.plan_tier
+                if dry_run:
+                    self.stdout.write(
+                        f"[dry-run] {tenant.slug}: {old_plan} -> {Tenant.PLAN_BASIC}"
+                    )
+                    continue
+
+                tenant.plan_tier = Tenant.PLAN_BASIC
+                tenant.save(update_fields=["plan_tier", "updated_at"])
+                migrated += 1
+
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Migrado {tenant.slug}: {old_plan} -> {Tenant.PLAN_BASIC}"
+                    )
+                )
+                logger.info(
+                    "Tenant migrated to basic plan",
+                    extra={
+                        "tenant_id": tenant.id,
+                        "old_plan": old_plan,
+                        "new_plan": Tenant.PLAN_BASIC,
+                    },
+                )
+
+            if dry_run:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"[dry-run] {total} tenant(s) seriam migrados. Nada foi alterado."
+                    )
+                )
+                return
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Concluído: {migrated} tenant(s) migrados para Basic.")
+        )

--- a/users/models.py
+++ b/users/models.py
@@ -136,6 +136,16 @@ class Tenant(models.Model):
         (PLAN_FOUNDER, "Founder"),  # DEPRECATED: Use PLAN_BASIC + is_founder=True
     ]
 
+    # BE-PLANS-01 (#481): planos bloqueados para venda/seleção. O Pro permanece em
+    # PLAN_CHOICES para preservar dados históricos e permitir reativação futura,
+    # mas não pode aparecer em listagens públicas nem ser atribuído via checkout.
+    BLOCKED_PLANS = [PLAN_PRO]
+
+    @classmethod
+    def is_plan_blocked(cls, plan_code) -> bool:
+        """Retorna se o plano está bloqueado para venda/seleção (BE-PLANS-01)."""
+        return plan_code in cls.BLOCKED_PLANS
+
     BILLING_MODE_STRIPE = "stripe"
     BILLING_MODE_PROMOTIONAL = "promotional"
     BILLING_MODE_CHOICES = [
@@ -356,23 +366,38 @@ class Tenant(models.Model):
         return self.can_use_advanced_reports()
 
     def can_use_advanced_reports(self):
-        """Verifica se pode usar relatórios avançados (Business Analysis + Insights) - Pro+"""
-        return self.plan_tier == self.PLAN_PRO
+        """Verifica se pode usar relatórios avançados (Business Analysis + Insights).
+
+        BE-PLANS-01 (#481): feature ex-Pro absorvida por todos os planos ativos.
+        """
+        return self.plan_tier in [self.PLAN_BASIC, self.PLAN_PRO, self.PLAN_FOUNDER]
 
     def can_use_pwa_client(self):
         """Verifica se pode usar PWA Cliente (Todos os planos)"""
         return self.pwa_client_enabled or self.plan_tier in [
             self.PLAN_BASIC,
             self.PLAN_PRO,
+            self.PLAN_FOUNDER,
         ]
 
     def can_use_white_label(self):
-        """Verifica se pode usar white-label (Pro apenas)"""
-        return self.plan_tier == self.PLAN_PRO
+        """Verifica se pode usar white-label.
+
+        BE-PLANS-01 (#481): feature ex-Pro absorvida por todos os planos ativos.
+        """
+        return self.plan_tier in [self.PLAN_BASIC, self.PLAN_PRO, self.PLAN_FOUNDER]
 
     def can_use_custom_domain(self):
-        """Verifica se o tenant pode usar domínio personalizado (Pro+)."""
-        return self.plan_tier == self.PLAN_PRO and bool(self.custom_domain_enabled)
+        """Verifica se o tenant pode usar domínio personalizado.
+
+        BE-PLANS-01 (#481): feature ex-Pro absorvida por todos os planos ativos;
+        continua dependendo da flag explícita custom_domain_enabled.
+        """
+        return self.plan_tier in [
+            self.PLAN_BASIC,
+            self.PLAN_PRO,
+            self.PLAN_FOUNDER,
+        ] and bool(self.custom_domain_enabled)
 
     def can_purchase_extra_credits(self):
         """Verifica se o tenant pode comprar créditos avulsos."""
@@ -383,19 +408,38 @@ class Tenant(models.Model):
         return self.comm_auto_renew
 
     def can_use_native_admin(self):
-        """Verifica se pode usar app nativo Admin (Pro+ ou flag explícita)"""
-        return self.rn_admin_enabled or self.plan_tier == self.PLAN_PRO
+        """Verifica se pode usar app nativo Admin.
+
+        BE-PLANS-01 (#481): feature ex-Pro absorvida por todos os planos ativos.
+        """
+        return self.rn_admin_enabled or self.plan_tier in [
+            self.PLAN_BASIC,
+            self.PLAN_PRO,
+            self.PLAN_FOUNDER,
+        ]
 
     def can_use_native_client(self):
-        """Verifica se pode usar app nativo Cliente (Pro+ ou flag explícita)"""
-        return self.rn_client_enabled or self.plan_tier == self.PLAN_PRO
+        """Verifica se pode usar app nativo Cliente.
+
+        BE-PLANS-01 (#481): feature ex-Pro absorvida por todos os planos ativos.
+        """
+        return self.rn_client_enabled or self.plan_tier in [
+            self.PLAN_BASIC,
+            self.PLAN_PRO,
+            self.PLAN_FOUNDER,
+        ]
 
     def can_use_native_apps(self):
         """Verifica se pode usar qualquer app nativo"""
         return self.can_use_native_admin() or self.can_use_native_client()
 
     def can_use_advanced_notifications(self):
-        allowed_by_plan = self.plan_tier == self.PLAN_PRO
+        # BE-PLANS-01 (#481): feature ex-Pro absorvida por todos os planos ativos.
+        allowed_by_plan = self.plan_tier in [
+            self.PLAN_BASIC,
+            self.PLAN_PRO,
+            self.PLAN_FOUNDER,
+        ]
         has_channel_flag = self.sms_enabled or self.whatsapp_enabled
         has_extra_credit = (
             bool(self.comm_extra_allowed) and (self.comm_credit_eur or 0) > 0
@@ -440,7 +484,11 @@ class Tenant(models.Model):
             return False
 
         self.billing_mode = self.BILLING_MODE_STRIPE
-        self.plan_tier = self.promotional_converts_to_plan
+        # BE-PLANS-01 (#481): nunca converter para um plano bloqueado.
+        target_plan = self.promotional_converts_to_plan
+        if self.is_plan_blocked(target_plan):
+            target_plan = self.PLAN_BASIC
+        self.plan_tier = target_plan
         self.promotional_expires_at = None
         self.save(
             update_fields=[
@@ -455,13 +503,16 @@ class Tenant(models.Model):
     # ===== Métodos para Sistema de Cancelamento (BE-ACCOUNT-CANCEL #396) =====
 
     def get_retention_days(self):
-        """Retorna dias de retenção baseado no plano."""
+        """Retorna dias de retenção baseado no plano.
+
+        BE-PLANS-01 (#481): Basic passa a 90 dias (paridade com o ex-Pro).
+        """
         RETENTION_DAYS = {
-            self.PLAN_BASIC: 30,
+            self.PLAN_BASIC: 90,
             self.PLAN_PRO: 90,
             self.PLAN_FOUNDER: 90,
         }
-        return RETENTION_DAYS.get(self.plan_tier, 30)
+        return RETENTION_DAYS.get(self.plan_tier, 90)
 
     def calculate_deletion_date(self):
         """Calcula data de hard delete baseada em cancelled_at + retenção."""

--- a/users/test_credits.py
+++ b/users/test_credits.py
@@ -99,13 +99,14 @@ class CreditServiceTestCase(TestCase):
             created_by=self.user,
         )
 
+        # BE-PLANS-01 (#481): plano Pro bloqueado não recebe crédito inicial,
+        # portanto o histórico contém apenas as transações criadas no teste.
         history = self.credit_service.get_credit_history()
-        self.assertEqual(len(history), 3)
+        self.assertEqual(len(history), 2)
 
         # Verifica ordenação (mais recente primeiro)
         self.assertEqual(history[0].description, "Test 2")
         self.assertEqual(history[1].description, "Test 1")
-        self.assertIn("Crédito inicial", history[2].description)
 
     def test_get_credit_stats(self):
         """Testa obtenção de estatísticas de créditos."""
@@ -130,8 +131,9 @@ class CreditServiceTestCase(TestCase):
 
         self.assertEqual(stats["total_purchased"], Decimal("10.00"))
         self.assertEqual(stats["total_consumed"], Decimal("3.00"))
-        # 5.00 (bonus test) + 15.00 (initial credit pro plan) = 20.00
-        self.assertEqual(stats["total_bonus"], Decimal("20.00"))
+        # BE-PLANS-01 (#481): Pro bloqueado não recebe crédito inicial;
+        # apenas os 5.00 do bônus criado no teste.
+        self.assertEqual(stats["total_bonus"], Decimal("5.00"))
 
 
 class CreditEndpointsTestCase(APITestCase):
@@ -184,7 +186,9 @@ class CreditEndpointsTestCase(APITestCase):
         data = response.json()
         results = data["results"]
 
-        self.assertEqual(len(results), 2)
+        # BE-PLANS-01 (#481): Pro bloqueado não recebe crédito inicial,
+        # então o histórico contém apenas a transação criada no teste.
+        self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["transaction_type"], "consumption")
         self.assertEqual(results[0]["amount_eur"], "2.00")
 
@@ -306,10 +310,12 @@ class TenantCreditMethodsTestCase(TestCase):
 
     def test_can_use_custom_domain(self):
         """Testa método can_use_custom_domain."""
+        # Sem a flag custom_domain_enabled, nenhum plano permite
         self.assertFalse(self.tenant_basic.can_use_custom_domain())
         self.assertTrue(self.tenant_pro.can_use_custom_domain())
 
-        # Mesmo com custom_domain_enabled=True, plano básico não deve permitir
+        # BE-PLANS-01 (#481): Basic absorveu domínio personalizado;
+        # com a flag habilitada, o Basic passa a permitir.
         self.tenant_basic.custom_domain_enabled = True
         self.tenant_basic.save()
-        self.assertFalse(self.tenant_basic.can_use_custom_domain())
+        self.assertTrue(self.tenant_basic.can_use_custom_domain())

--- a/users/tests/test_auth.py
+++ b/users/tests/test_auth.py
@@ -206,9 +206,10 @@ class TestAuthEndpoints:
         )
         assert refresh_resp.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_me_profile_admin_app_denied_for_basic_tenant(
+    def test_me_profile_admin_app_allowed_for_basic_tenant(
         self, user_fixture, tenant_fixture
     ):
+        """BE-PLANS-01 (#481): Basic absorveu apps nativos; Admin App liberado."""
         tenant_fixture.plan_tier = "basic"
         tenant_fixture.rn_admin_enabled = False
         tenant_fixture.save(
@@ -218,11 +219,7 @@ class TestAuthEndpoints:
         self.client.force_authenticate(user=user_fixture)
         response = self.client.get(self.me_profile_url, HTTP_X_APP_TYPE="admin")
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.data["error"]["code"] == "E004"
-        assert response.data["error"]["details"]["code"] == "PLAN_UPGRADE_REQUIRED"
-        assert response.data["error"]["details"]["current_plan"] == "basic"
-        assert response.data["error"]["details"]["plan_required"] == "pro"
+        assert response.status_code == status.HTTP_200_OK
 
     def test_me_profile_admin_app_allowed_for_pro_tenant(self, user_fixture):
         self.client.force_authenticate(user=user_fixture)

--- a/users/tests/test_feature_flags.py
+++ b/users/tests/test_feature_flags.py
@@ -29,16 +29,18 @@ class TestTenantFeatureFlags:
             plan_tier=Tenant.PLAN_BASIC,
         )
 
-        # Basic: PWA Admin/Client habilitado e Relatórios Básicos
+        # BE-PLANS-01 (#481): Basic absorveu todas as features ex-Pro
         assert tenant.can_use_reports()  # Basic reports
         assert tenant.can_use_basic_reports()
-        assert not tenant.can_use_standard_reports()
-        assert not tenant.can_use_advanced_reports()
+        assert tenant.can_use_standard_reports()
+        assert tenant.can_use_advanced_reports()
 
         assert tenant.can_use_pwa_client()
-        assert not tenant.can_use_white_label()
-        assert not tenant.can_use_native_apps()
-        assert not tenant.can_use_advanced_notifications()
+        assert tenant.can_use_white_label()
+        assert tenant.can_use_native_apps()
+        # sms_enabled tem default True; com canal habilitado e plano ativo,
+        # notificações avançadas ficam disponíveis (feature ex-Pro absorvida)
+        assert tenant.can_use_advanced_notifications()
 
         # PWA Admin sempre habilitado
         assert tenant.pwa_admin_enabled
@@ -93,7 +95,9 @@ class TestTenantFeatureFlags:
         tenant.comm_credit_eur = 0
         tenant.save()
 
-        assert tenant.can_use_advanced_notifications() is False
+        # BE-PLANS-01 (#481): Basic absorveu notificações avançadas por plano;
+        # com canal habilitado, não depende mais de créditos extras.
+        assert tenant.can_use_advanced_notifications() is True
 
     def test_feature_flags_override(self):
         """Teste que feature flags específicas sobrescrevem lógica de plano."""
@@ -252,10 +256,14 @@ class TestRequiresFeatureFlagPermission:
         assert permission.has_permission(request, None) is True
 
     def test_permission_without_feature(self, tenant_fixture, user_fixture):
-        """Teste permission com feature desabilitada (usando white_label que Basic não tem)."""
-        # Tenant básico não tem white_label
+        """Teste permission com feature desabilitada.
+
+        BE-PLANS-01 (#481): white_label passou a ser permitido para todos os
+        planos ativos; usamos push_mobile com flag desabilitada para validar
+        o caminho de negação.
+        """
         tenant_fixture.plan_tier = Tenant.PLAN_BASIC
-        # white_label não tem flag booleana direta no model (depende do plano), mas o check verifica o plano
+        tenant_fixture.push_mobile_enabled = False
         tenant_fixture.save()
 
         user_fixture.tenant = tenant_fixture
@@ -266,8 +274,7 @@ class TestRequiresFeatureFlagPermission:
         request = Mock()
         request.user = user_fixture
 
-        # Basic não tem white_label
-        permission = RequiresFeatureFlag("white_label")
+        permission = RequiresFeatureFlag("push_mobile")
         assert permission.has_permission(request, None) is False
 
     def test_permission_without_tenant(self):
@@ -442,26 +449,21 @@ class TestPlanUpgradeScenarios:
     """Testes para cenários de upgrade de plano."""
 
     def test_basic_to_pro_upgrade(self):
-        """Teste upgrade de Basic para Pro."""
+        """BE-PLANS-01 (#481): Basic já possui todas as features ex-Pro;
+        upgrade para Pro está bloqueado e não é mais necessário."""
         tenant = Tenant.objects.create(
             name="Upgrade Salon",
             slug="upgrade-salon",
             plan_tier=Tenant.PLAN_BASIC,
         )
 
-        # Antes do upgrade
+        # Basic já tem tudo que era do Pro
         assert tenant.can_use_reports()
         assert tenant.can_use_basic_reports()
-        assert not tenant.can_use_standard_reports()
-        assert tenant.can_use_pwa_client()
-
-        # Simular upgrade
-        tenant.plan_tier = Tenant.PLAN_PRO
-        tenant.save()
-
-        # Depois do upgrade
-        assert tenant.can_use_reports()
         assert tenant.can_use_standard_reports()
         assert tenant.can_use_advanced_reports()
         assert tenant.can_use_pwa_client()
-        assert tenant.can_use_white_label()  # Pro tem white-label
+        assert tenant.can_use_white_label()
+
+        # E o plano Pro está bloqueado para novas atribuições
+        assert Tenant.is_plan_blocked(Tenant.PLAN_PRO) is True

--- a/users/tests/test_mobile_app_access.py
+++ b/users/tests/test_mobile_app_access.py
@@ -11,6 +11,8 @@ Cenários testados:
 - Web login (sem header) funciona independente do plano
 """
 
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -102,12 +104,8 @@ class TestMobileAppAccessControl:
     # ADMIN APP ACCESS TESTS
     # ========================================================================
 
-    def test_basic_tenant_cannot_access_admin_app(self, tenant_basic):
-        """
-        Basic tenant (€29) tenta logar no Admin App → HTTP 403
-
-        Expectativa: Backend bloqueia com mensagem de upgrade
-        """
+    def test_basic_tenant_can_access_admin_app(self, tenant_basic):
+        """BE-PLANS-01 (#481): Basic absorveu apps nativos; login admin liberado."""
         response = self.client.post(
             self.token_url,
             data={
@@ -116,6 +114,23 @@ class TestMobileAppAccessControl:
             },
             HTTP_X_APP_TYPE="admin",
         )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "access" in response.data
+
+    def test_tenant_without_entitlement_cannot_access_admin_app(self, tenant_basic):
+        """Sem entitlement (mockado), login no Admin App → HTTP 403 com upgrade."""
+        from users.models import Tenant
+
+        with patch.object(Tenant, "can_use_native_admin", return_value=False):
+            response = self.client.post(
+                self.token_url,
+                data={
+                    "email": "owner@basictenant.com",
+                    "password": "Test123!@#",
+                },
+                HTTP_X_APP_TYPE="admin",
+            )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "detail" in response.data
@@ -167,12 +182,8 @@ class TestMobileAppAccessControl:
     # CLIENT APP ACCESS TESTS
     # ========================================================================
 
-    def test_basic_tenant_cannot_access_client_app(self, tenant_basic):
-        """
-        Basic tenant (€29) tenta logar no Client App → HTTP 403
-
-        Expectativa: Backend bloqueia com mensagem de upgrade para Pro
-        """
+    def test_basic_tenant_can_access_client_app(self, tenant_basic):
+        """BE-PLANS-01 (#481): Basic absorveu apps nativos; login client liberado."""
         response = self.client.post(
             self.token_url,
             data={
@@ -181,6 +192,23 @@ class TestMobileAppAccessControl:
             },
             HTTP_X_APP_TYPE="client",
         )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "access" in response.data
+
+    def test_tenant_without_entitlement_cannot_access_client_app(self, tenant_basic):
+        """Sem entitlement (mockado), login no Client App → HTTP 403 com upgrade."""
+        from users.models import Tenant
+
+        with patch.object(Tenant, "can_use_native_client", return_value=False):
+            response = self.client.post(
+                self.token_url,
+                data={
+                    "email": "owner@basictenant.com",
+                    "password": "Test123!@#",
+                },
+                HTTP_X_APP_TYPE="client",
+            )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Pro" in response.data["detail"]  # Mention Pro plan
@@ -309,14 +337,17 @@ class TestMobileAppAccessControl:
 
         Expectativa: Payload estruturado para frontend exibir modal de upgrade
         """
-        response = self.client.post(
-            self.token_url,
-            data={
-                "email": "owner@basictenant.com",
-                "password": "Test123!@#",
-            },
-            HTTP_X_APP_TYPE="admin",
-        )
+        from users.models import Tenant
+
+        with patch.object(Tenant, "can_use_native_admin", return_value=False):
+            response = self.client.post(
+                self.token_url,
+                data={
+                    "email": "owner@basictenant.com",
+                    "password": "Test123!@#",
+                },
+                HTTP_X_APP_TYPE="admin",
+            )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -361,14 +392,17 @@ class TestMobileAppAccessControl:
 
         Expectativa: Backend normaliza header para lowercase
         """
-        response = self.client.post(
-            self.token_url,
-            data={
-                "email": "owner@basictenant.com",
-                "password": "Test123!@#",
-            },
-            HTTP_X_APP_TYPE="ADMIN",  # Uppercase
-        )
+        from users.models import Tenant
+
+        with patch.object(Tenant, "can_use_native_admin", return_value=False):
+            response = self.client.post(
+                self.token_url,
+                data={
+                    "email": "owner@basictenant.com",
+                    "password": "Test123!@#",
+                },
+                HTTP_X_APP_TYPE="ADMIN",  # Uppercase
+            )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data["plan_required"] == "pro"
@@ -446,15 +480,18 @@ class TestMobileAppAccessMetrics:
             event="login_admin_denied", result="failure"
         )._value._value
 
-        # Attempt login
-        self.client.post(
-            self.token_url,
-            data={
-                "email": "owner@basictenant.com",
-                "password": "Test123!@#",
-            },
-            HTTP_X_APP_TYPE="admin",
-        )
+        # Attempt login (entitlement mockado para exercitar negação)
+        from users.models import Tenant
+
+        with patch.object(Tenant, "can_use_native_admin", return_value=False):
+            self.client.post(
+                self.token_url,
+                data={
+                    "email": "owner@basictenant.com",
+                    "password": "Test123!@#",
+                },
+                HTTP_X_APP_TYPE="admin",
+            )
 
         # Verify metric incremented
         final_value = USERS_AUTH_EVENTS_TOTAL.labels(
@@ -475,14 +512,17 @@ class TestMobileAppAccessMetrics:
             event="login_client_denied", result="failure"
         )._value._value
 
-        self.client.post(
-            self.token_url,
-            data={
-                "email": "owner@basictenant.com",
-                "password": "Test123!@#",
-            },
-            HTTP_X_APP_TYPE="client",
-        )
+        from users.models import Tenant
+
+        with patch.object(Tenant, "can_use_native_client", return_value=False):
+            self.client.post(
+                self.token_url,
+                data={
+                    "email": "owner@basictenant.com",
+                    "password": "Test123!@#",
+                },
+                HTTP_X_APP_TYPE="client",
+            )
 
         final_value = USERS_AUTH_EVENTS_TOTAL.labels(
             event="login_client_denied", result="failure"

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -6,6 +6,8 @@ A permissão avalia o header X-App-Type (admin/client/web) e verifica o
 entitlement do tenant antes de conceder acesso.
 """
 
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.exceptions import PermissionDenied
@@ -188,15 +190,27 @@ class TestRequiresMobileAccessPermission:
     # Admin App — X-App-Type: admin
     # ------------------------------------------------------------------
 
-    def test_basic_tenant_admin_app_is_denied_with_payload(
+    def test_basic_tenant_admin_app_is_allowed(
         self, factory, tenant_basic, django_user_model
     ):
-        """Basic com X-App-Type: admin deve levantar 403 com payload de upgrade."""
+        """BE-PLANS-01 (#481): Basic absorveu apps nativos; admin liberado."""
+        user = django_user_model.objects.get(email="owner@basictenant.com")
+        request = _make_request(factory, app_type="admin")
+        request.user = user
+        assert RequiresMobileAccess().has_permission(request, MockMobileView()) is True
+
+    def test_tenant_without_entitlement_admin_app_is_denied_with_payload(
+        self, factory, tenant_basic, django_user_model
+    ):
+        """Sem entitlement (mockado), X-App-Type: admin deve levantar 403 com payload."""
+        from users.models import Tenant
+
         user = django_user_model.objects.get(email="owner@basictenant.com")
         request = _make_request(factory, app_type="admin")
         request.user = user
 
-        with pytest.raises(PermissionDenied) as exc_info:
+        with patch.object(Tenant, "can_use_native_admin", return_value=False), \
+                pytest.raises(PermissionDenied) as exc_info:
             RequiresMobileAccess().has_permission(request, MockMobileView())
 
         detail = exc_info.value.detail
@@ -228,15 +242,27 @@ class TestRequiresMobileAccessPermission:
     # Client App — X-App-Type: client
     # ------------------------------------------------------------------
 
-    def test_basic_tenant_client_app_is_denied_with_payload(
+    def test_basic_tenant_client_app_is_allowed_by_plan(
         self, factory, tenant_basic, django_user_model
     ):
-        """Basic com X-App-Type: client deve levantar 403 com payload de upgrade."""
+        """BE-PLANS-01 (#481): Basic absorveu apps nativos; client liberado."""
+        user = django_user_model.objects.get(email="owner@basictenant.com")
+        request = _make_request(factory, app_type="client")
+        request.user = user
+        assert RequiresMobileAccess().has_permission(request, MockMobileView()) is True
+
+    def test_tenant_without_entitlement_client_app_is_denied_with_payload(
+        self, factory, tenant_basic, django_user_model
+    ):
+        """Sem entitlement (mockado), X-App-Type: client deve levantar 403 com payload."""
+        from users.models import Tenant
+
         user = django_user_model.objects.get(email="owner@basictenant.com")
         request = _make_request(factory, app_type="client")
         request.user = user
 
-        with pytest.raises(PermissionDenied) as exc_info:
+        with patch.object(Tenant, "can_use_native_client", return_value=False), \
+                pytest.raises(PermissionDenied) as exc_info:
             RequiresMobileAccess().has_permission(request, MockMobileView())
 
         detail = exc_info.value.detail
@@ -272,16 +298,20 @@ class TestRequiresMobileAccessPermission:
         self, factory, tenant_basic, django_user_model
     ):
         """Mensagem de erro deve diferenciar Admin App de Client App."""
+        from users.models import Tenant
+
         user = django_user_model.objects.get(email="owner@basictenant.com")
 
         request_admin = _make_request(factory, app_type="admin")
         request_admin.user = user
-        with pytest.raises(PermissionDenied) as admin_exc:
+        with patch.object(Tenant, "can_use_native_admin", return_value=False), \
+                pytest.raises(PermissionDenied) as admin_exc:
             RequiresMobileAccess().has_permission(request_admin, MockMobileView())
 
         request_client = _make_request(factory, app_type="client")
         request_client.user = user
-        with pytest.raises(PermissionDenied) as client_exc:
+        with patch.object(Tenant, "can_use_native_client", return_value=False), \
+                pytest.raises(PermissionDenied) as client_exc:
             RequiresMobileAccess().has_permission(request_client, MockMobileView())
 
         assert admin_exc.value.detail["detail"] != client_exc.value.detail["detail"]
@@ -294,11 +324,14 @@ class TestRequiresMobileAccessPermission:
         self, factory, tenant_basic, django_user_model
     ):
         """X-App-Type: ADMIN (maiúsculo) deve ser tratado igual a admin."""
+        from users.models import Tenant
+
         user = django_user_model.objects.get(email="owner@basictenant.com")
         request = _make_request(factory, app_type="ADMIN")
         request.user = user
 
-        with pytest.raises(PermissionDenied) as exc_info:
+        with patch.object(Tenant, "can_use_native_admin", return_value=False), \
+                pytest.raises(PermissionDenied) as exc_info:
             RequiresMobileAccess().has_permission(request, MockMobileView())
 
         assert exc_info.value.detail["code"] == "PLAN_UPGRADE_REQUIRED"

--- a/users/tests/test_plan_blocking.py
+++ b/users/tests/test_plan_blocking.py
@@ -1,0 +1,199 @@
+"""
+Testes do BE-PLANS-01 (#481): bloqueio do plano Pro e absorção das suas
+features pelos planos Basic e Founder.
+"""
+
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from rest_framework.test import APIClient
+
+from payments.services import SubscriptionService
+from users.models import CustomUser, Tenant, TenantStaffMember
+
+
+@pytest.fixture
+def basic_tenant(db):
+    return Tenant.objects.create(
+        name="Salon Basic", slug="salon-basic", plan_tier=Tenant.PLAN_BASIC
+    )
+
+
+@pytest.fixture
+def founder_tenant(db):
+    return Tenant.objects.create(
+        name="Salon Founder",
+        slug="salon-founder",
+        plan_tier=Tenant.PLAN_FOUNDER,
+        is_founder=True,
+    )
+
+
+@pytest.fixture
+def pro_tenant(db):
+    return Tenant.objects.create(
+        name="Salon Pro", slug="salon-pro", plan_tier=Tenant.PLAN_PRO
+    )
+
+
+def _make_owner(tenant, username):
+    user = CustomUser.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="pass",
+        tenant=tenant,
+    )
+    TenantStaffMember.objects.create(
+        tenant=tenant, user=user, role=TenantStaffMember.Role.OWNER
+    )
+    return user
+
+
+class TestPlanBlocked:
+    def test_pro_is_blocked(self):
+        assert Tenant.is_plan_blocked(Tenant.PLAN_PRO) is True
+
+    def test_basic_and_founder_are_not_blocked(self):
+        assert Tenant.is_plan_blocked(Tenant.PLAN_BASIC) is False
+        assert Tenant.is_plan_blocked(Tenant.PLAN_FOUNDER) is False
+
+    def test_pro_absent_from_available_plans(self, db):
+        plans = SubscriptionService.get_available_plans()
+        plan_codes = [p["plan_code"] for p in plans]
+        assert "pro" not in plan_codes
+        assert "basic" in plan_codes
+
+    @pytest.mark.django_db
+    def test_checkout_with_pro_rejected(self, basic_tenant):
+        owner = _make_owner(basic_tenant, "owner-basic")
+        client = APIClient()
+        client.force_authenticate(user=owner)
+
+        # View legada de checkout
+        resp = client.post(
+            "/api/payments/stripe/create-checkout-session/",
+            {"plan": "pro"},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+        # View v2 (serializer com validate_plan)
+        resp_v2 = client.post(
+            "/api/payments/stripe/v2/checkout/", {"plan": "pro"}, format="json"
+        )
+        assert resp_v2.status_code == 400
+
+    @pytest.mark.django_db
+    def test_promotional_transition_never_converts_to_blocked_plan(
+        self, basic_tenant
+    ):
+        from django.utils import timezone
+        from datetime import timedelta
+
+        basic_tenant.billing_mode = Tenant.BILLING_MODE_PROMOTIONAL
+        basic_tenant.promotional_expires_at = timezone.now() - timedelta(days=1)
+        basic_tenant.promotional_converts_to_plan = Tenant.PLAN_PRO
+        basic_tenant.save()
+
+        assert basic_tenant.apply_promotional_transition() is True
+        basic_tenant.refresh_from_db()
+        assert basic_tenant.plan_tier == Tenant.PLAN_BASIC
+
+
+class TestBasicAbsorbsProFeatures:
+    @pytest.mark.django_db
+    def test_basic_has_ex_pro_features(self, basic_tenant):
+        assert basic_tenant.can_use_advanced_reports() is True
+        assert basic_tenant.can_use_white_label() is True
+        assert basic_tenant.can_use_native_admin() is True
+        assert basic_tenant.can_use_native_client() is True
+
+    @pytest.mark.django_db
+    def test_founder_has_ex_pro_features(self, founder_tenant):
+        assert founder_tenant.can_use_advanced_reports() is True
+        assert founder_tenant.can_use_white_label() is True
+        assert founder_tenant.can_use_native_admin() is True
+        assert founder_tenant.can_use_native_client() is True
+
+    @pytest.mark.django_db
+    def test_basic_retention_is_90_days(self, basic_tenant):
+        assert basic_tenant.get_retention_days() == 90
+
+    @pytest.mark.django_db
+    def test_basic_advanced_notifications_by_plan(self, basic_tenant):
+        basic_tenant.sms_enabled = True
+        basic_tenant.save(update_fields=["sms_enabled"])
+        assert basic_tenant.can_use_advanced_notifications() is True
+
+    @pytest.mark.django_db
+    def test_custom_domain_still_requires_flag(self, basic_tenant):
+        assert basic_tenant.can_use_custom_domain() is False
+        basic_tenant.custom_domain_enabled = True
+        basic_tenant.save(update_fields=["custom_domain_enabled"])
+        assert basic_tenant.can_use_custom_domain() is True
+
+    @pytest.mark.django_db
+    def test_basic_owner_can_enable_auto_renewal(self, basic_tenant):
+        owner = _make_owner(basic_tenant, "owner-renew")
+        client = APIClient()
+        client.force_authenticate(user=owner)
+
+        resp = client.patch(
+            "/api/payments/stripe/settings/", {"auto_renewal": True}, format="json"
+        )
+        assert resp.status_code == 200
+        assert resp.data["auto_renewal"] is True
+
+    @pytest.mark.django_db
+    def test_basic_prices_and_credits_unchanged(self, db):
+        basic = SubscriptionService.AVAILABLE_PLANS["basic"]
+        assert str(basic["price_monthly"]) == "29.00"
+        assert str(basic["credits_included"]) == "5.00"
+
+
+class TestOpsBlockedPlan:
+    def test_ops_serializer_rejects_blocked_plan(self, db):
+        from ops.serializers import OpsTenantPlanUpdateSerializer
+
+        serializer = OpsTenantPlanUpdateSerializer(data={"plan_tier": "pro"})
+        assert serializer.is_valid() is False
+        assert "plan_tier" in serializer.errors
+
+    def test_ops_serializer_accepts_basic(self, db):
+        from ops.serializers import OpsTenantPlanUpdateSerializer
+
+        serializer = OpsTenantPlanUpdateSerializer(data={"plan_tier": "basic"})
+        assert serializer.is_valid() is True
+
+
+class TestMigrateTenantsToBasicCommand:
+    @pytest.mark.django_db
+    def test_migrates_pro_tenant_to_basic(self, pro_tenant, founder_tenant):
+        out = StringIO()
+        call_command("migrate_tenants_to_basic", stdout=out)
+
+        pro_tenant.refresh_from_db()
+        founder_tenant.refresh_from_db()
+        assert pro_tenant.plan_tier == Tenant.PLAN_BASIC
+        assert founder_tenant.plan_tier == Tenant.PLAN_FOUNDER
+        assert "salon-pro" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_idempotent(self, pro_tenant):
+        call_command("migrate_tenants_to_basic", stdout=StringIO())
+        out = StringIO()
+        call_command("migrate_tenants_to_basic", stdout=out)
+
+        pro_tenant.refresh_from_db()
+        assert pro_tenant.plan_tier == Tenant.PLAN_BASIC
+        assert "Nada a migrar" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_dry_run_does_not_change(self, pro_tenant):
+        out = StringIO()
+        call_command("migrate_tenants_to_basic", "--dry-run", stdout=out)
+
+        pro_tenant.refresh_from_db()
+        assert pro_tenant.plan_tier == Tenant.PLAN_PRO
+        assert "dry-run" in out.getvalue()

--- a/users/tests/test_plan_features.py
+++ b/users/tests/test_plan_features.py
@@ -21,13 +21,14 @@ class TestPlanFeatures:
             plan_tier=Tenant.PLAN_BASIC,
         )
 
-        # Features esperadas
+        # BE-PLANS-01 (#481): Basic absorveu todas as features ex-Pro
         assert tenant.can_use_basic_reports() is True
-        assert tenant.can_use_standard_reports() is False
-        assert tenant.can_use_advanced_reports() is False
-        assert tenant.can_use_pwa_client() is True  # Basic tem PWA Cliente
-        assert tenant.can_use_native_apps() is False  # Apenas Pro
-        assert tenant.can_use_white_label() is False
+        assert tenant.can_use_standard_reports() is True
+        assert tenant.can_use_advanced_reports() is True
+        assert tenant.can_use_pwa_client() is True
+        assert tenant.can_use_native_apps() is True
+        assert tenant.can_use_white_label() is True
+        # Domínio custom continua dependendo da flag explícita
         assert tenant.can_use_custom_domain() is False
 
     def test_pro_plan_features(self):
@@ -61,14 +62,13 @@ class TestPlanFeatures:
             is_founder=True,
         )
 
-        # Deve ter as mesmas features do Basic
+        # BE-PLANS-01 (#481): Founder/Basic têm todas as features ex-Pro
         assert tenant.can_use_basic_reports() is True
-        assert tenant.can_use_standard_reports() is False
-        assert tenant.can_use_advanced_reports() is False
+        assert tenant.can_use_standard_reports() is True
+        assert tenant.can_use_advanced_reports() is True
         assert tenant.can_use_pwa_client() is True
-
-        # Founder NÃO deve ter features do Pro
-        assert tenant.can_use_white_label() is False
+        assert tenant.can_use_white_label() is True
+        # Domínio custom continua dependendo da flag explícita
         assert tenant.can_use_custom_domain() is False
 
     def test_founder_plan_credits(self):
@@ -104,16 +104,14 @@ class TestPlanFeatures:
         assert tenant.can_use_basic_reports() is True
 
         # E PWA Client?
-        # Pelo código atual: NÃO, can_use_pwa_client só checa Basic e Pro.
-        # A menos que pwa_client_enabled seja True (default é True no model).
         assert tenant.pwa_client_enabled is True
         assert tenant.can_use_pwa_client() is True
 
-        # Se desligarmos a flag explicita?
+        # BE-PLANS-01 (#481): PLAN_FOUNDER entrou na lista de planos permitidos
+        # de can_use_pwa_client; mesmo sem a flag explícita, mantém acesso.
         tenant.pwa_client_enabled = False
         tenant.save()
-        # Aqui ele perderia acesso se o tier não estivesse na lista allowed
-        assert tenant.can_use_pwa_client() is False
+        assert tenant.can_use_pwa_client() is True
 
         # Conclusão: É seguro manter PLAN_FOUNDER como fallback,
         # mas o ideal é que todos sejam plan_tier='basic'.

--- a/users/tests/test_tenant_cancellation_new.py
+++ b/users/tests/test_tenant_cancellation_new.py
@@ -342,7 +342,9 @@ class CeleryTasksTest(APITestCase):
             name="Test Salon",
             slug="test-salon",
             status=Tenant.STATUS_CANCELLED,
-            cancelled_at=timezone.now() - timedelta(days=61),
+            # BE-PLANS-01 (#481): retenção do Basic passou a 90 dias;
+            # 95 dias garante que o período de reativação já expirou.
+            cancelled_at=timezone.now() - timedelta(days=95),
             scheduled_deletion_at=timezone.now() - timedelta(days=1),
         )
 

--- a/users/tests/test_tenant_credits.py
+++ b/users/tests/test_tenant_credits.py
@@ -30,20 +30,17 @@ class TestTenantInitialCredits:
         assert ledger_entry.balance_after == Decimal("5.00")
 
     def test_pro_plan_initial_credits(self):
-        """Testa se o plano Pro recebe 15€ de crédito inicial."""
+        """BE-PLANS-01 (#481): Pro bloqueado não recebe crédito inicial."""
         tenant = Tenant.objects.create(
             name="Tenant Pro",
             slug="tenant-pro-credits",
             plan_tier=Tenant.PLAN_PRO
         )
-        
+
         tenant.refresh_from_db()
-        
-        assert tenant.comm_credit_eur == Decimal("15.00")
-        
-        ledger_entry = CommLedger.objects.get(tenant=tenant)
-        assert ledger_entry.amount_eur == Decimal("15.00")
-        assert ledger_entry.balance_after == Decimal("15.00")
+
+        assert tenant.comm_credit_eur == Decimal("0.00")
+        assert CommLedger.objects.filter(tenant=tenant).count() == 0
 
     def test_update_does_not_trigger_credits(self):
         """Testa se atualizações subsequentes não duplicam créditos."""

--- a/users/views.py
+++ b/users/views.py
@@ -2050,12 +2050,18 @@ class TenantNotificationsSettingsView(APIView):
             tenant.whatsapp_enabled = bool(v["whatsapp_enabled"])
             updates.add("whatsapp_enabled")
         if "push_mobile_enabled" in v:
+            # BE-PLANS-01 (#481): push mobile era exclusivo do Pro; feature
+            # absorvida por todos os planos ativos.
             desired = bool(v["push_mobile_enabled"])
-            if desired and tenant.plan_tier != Tenant.PLAN_PRO:
+            if desired and tenant.plan_tier not in (
+                Tenant.PLAN_BASIC,
+                Tenant.PLAN_PRO,
+                Tenant.PLAN_FOUNDER,
+            ):
                 return Response(
                     {
                         "detail": (
-                            "Push Mobile só disponível para plano Pro. "
+                            "Push Mobile disponível a partir do plano Basic. "
                             "Atualize seu plano para ativar."
                         )
                     },


### PR DESCRIPTION
Closes #481

## O que muda

O plano **Pro fica bloqueado** — invisível em listagens públicas e impossível de
contratar — mas **preservado no código** para reativação futura. **Basic e Founder
absorvem todas as features ex-Pro**; preços e créditos não mudam (Basic €29/€5,
Founder €15/€2).

## Como

- **Fonte única de bloqueio**: `Tenant.BLOCKED_PLANS` + `Tenant.is_plan_blocked()` —
  Pro continua em `PLAN_CHOICES` para dados históricos.
- **Fluxos públicos**: Pro filtrado de `get_available_plans()`; checkout rejeita
  `plan="pro"` com erro claro (view legada e v2); console OPS também rejeita.
- **Webhooks Stripe com guarda**: evento residual de Pro não altera `plan_tier` —
  loga warning, sem erro silencioso. Conversão promocional nunca converte para
  plano bloqueado.
- **Gating expandido**: `can_use_advanced_reports`, `can_use_white_label`,
  `can_use_custom_domain` (mantém flag), `can_use_native_admin/client`,
  `can_use_advanced_notifications` e push mobile passam a incluir Basic e Founder;
  retenção do Basic sobe de 30 para 90 dias; `plan_hierarchy` do `requires_plan`
  nivelada (corrige bug: Founder não estava na hierarquia e falharia checks
  `requires_plan('pro')`).
- **Migração**: novo command `migrate_tenants_to_basic` (idempotente, `--dry-run`,
  transação atômica, log por tenant) — migra os 2 tenants de teste de produção;
  Founder não é tocado.
- **Django Admin**: ação "Upgrade para Pro" removida; Pro fora dos choices
  (`plan_tier`, `promotional_converts_to_plan`) e do filtro lateral (filtro customizado).
- **OPS**: lógica de conflitos "não-Pro não suporta SMS/WhatsApp/addons" removida —
  mudança de plano não desativa mais esses recursos.

## Testes

- **906 passed, 5 skipped** na suite completa.
- 17 testes novos em `users/tests/test_plan_blocking.py` (bloqueio, absorção,
  preços inalterados, command, OPS).
- ~25 testes existentes atualizados em 13 arquivos; cobertura do payload 403
  `PLAN_UPGRADE_REQUIRED` preservada via mock de entitlement (não há mais plano
  ativo negado nos apps mobile).

## Pós-merge

1. Rodar `python manage.py migrate_tenants_to_basic` em produção
   (sem migrações de schema neste PR).
2. Coordenar FEW-PLANS-01 (frontend) e MOB-PLANS-01 (mobile).

Documentação completa em `docs/PLANOS_BLOQUEIO_PRO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
